### PR TITLE
Not writing axis if the joint is a 'fixed' joint

### DIFF
--- a/SW2URDF/URDFExporter/URDF.cs
+++ b/SW2URDF/URDFExporter/URDF.cs
@@ -1141,6 +1141,9 @@ namespace SW2URDF
             Origin.WriteURDF(writer);
             Parent.WriteURDF(writer);
             Child.WriteURDF(writer);
+
+            // Since the axis parameter is optional, this will only write it as long as the type
+            // is not 'fixed
             if (!TypeAttribute.value.Equals("fixed"))
             {
                 Axis.WriteURDF(writer);


### PR DESCRIPTION
According to Andy, Verb was having difficulties if a 'fixed' joint also contained an axis parameter, especially if it was all zeroes. Since, the axis parameter is optional, this will only write it as long as the type is not 'fixed'.