### PR TITLE
Fixing unfixing bug

### DIFF
--- a/SW2URDF/URDFExporter/URDFExporterExtension.cs
+++ b/SW2URDF/URDFExporter/URDFExporterExtension.cs
@@ -713,7 +713,7 @@ namespace SW2URDF
         public Boolean EstimateGlobalJointFromComponents(AssemblyDoc assy, Link parent, Link child)
         {
             //Create the ref objects
-            int DOFs;
+            int degreesOfFreedom;
 
             // Fix parent components so that only the actual degree of freedom can be detected.
             List<Component2> fixedComponents = FixComponents(parent);
@@ -766,14 +766,14 @@ namespace SW2URDF
                     logger.Info("L2: " + L2Status);
                 }
 
-                DOFs = remainingDOFs;
+                degreesOfFreedom = remainingDOFs;
 
                 // Convert the gotten degrees of freedom to a joint type, origin and axis
                 child.Joint.Type = "fixed";
                 child.Joint.Origin.SetXYZ(MathOps.GetXYZ(child.SWMainComponent.Transform2));
                 child.Joint.Origin.SetRPY(MathOps.GetRPY(child.SWMainComponent.Transform2));
 
-                if (DOFs == 0 && (R1Status + L1Status > 0))
+                if (degreesOfFreedom == 0 && (R1Status + L1Status > 0))
                 {
                     success = true;
                     if (R1Status == 1)


### PR DESCRIPTION
This was an issue when automatically computing the degrees of freedom of components. This should now properly fix and unfix components.

I moved the calls to fix/unfix components to the only method that actually needed them to be fixed/unfixed. This makes it a bit easier to reason about which components need to be fixed/unfixed.