### PR TITLE
Registering component and removing settings file

### DIFF
--- a/SW2URDF/SW2URDF.csproj
+++ b/SW2URDF/SW2URDF.csproj
@@ -139,7 +139,7 @@
     <BaseAddress>285212672</BaseAddress>
     <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
     <FileAlignment>4096</FileAlignment>
-    <RegisterForComInterop>false</RegisterForComInterop>
+    <RegisterForComInterop>true</RegisterForComInterop>
     <DebugType>full</DebugType>
     <PlatformTarget>x64</PlatformTarget>
     <ErrorReport>prompt</ErrorReport>
@@ -216,11 +216,6 @@
       <DesignTime>True</DesignTime>
       <DependentUpon>Resources.resx</DependentUpon>
     </Compile>
-    <Compile Include="Properties\Settings.Designer.cs">
-      <AutoGen>True</AutoGen>
-      <DesignTimeSharedInput>True</DesignTimeSharedInput>
-      <DependentUpon>Settings.settings</DependentUpon>
-    </Compile>
     <Compile Include="ROSFiles.cs" />
     <Compile Include="URDFExporter\AssemblyExportForm.cs">
       <SubType>Form</SubType>
@@ -296,10 +291,6 @@
   <ItemGroup>
     <None Include="Properties\DataSources\SwAddin.datasource">
       <SubType>Designer</SubType>
-    </None>
-    <None Include="Properties\Settings.settings">
-      <Generator>SettingsSingleFileGenerator</Generator>
-      <LastGenOutput>Settings.Designer.cs</LastGenOutput>
     </None>
     <None Include="SW2URDF.ruleset" />
   </ItemGroup>


### PR DESCRIPTION
Re-installing this on a new machine, I realized there were a couple of project configuration issues. The add-in didn't properly register with the system, and there was also an empty settings file referenced in the project solution. This address both