### PR TITLE
Reducing number of calls to GetFeaturesOfType to only when the PM ope…

### DIFF
--- a/SW2URDF/URDFExporter/URDFExporterExtension.cs
+++ b/SW2URDF/URDFExporter/URDFExporterExtension.cs
@@ -1052,7 +1052,7 @@ namespace SW2URDF
             bool topLevelOnly, string keyName, Dictionary<string, List<Feature>> features)
         {
             string fileName = (string.IsNullOrWhiteSpace(keyName)) ? modelDoc.GetTitle() : keyName;
-            logger.Info("Retreiving features of type [" + featureName + "] from " + fileName);
+            logger.Info("Retrieving features of type [" + featureName + "] from " + fileName);
 
             features[keyName] = new List<Feature>();
 


### PR DESCRIPTION
Previously this plug-in would recur through the SW assembly tree to find all coordinate systems and axes to populate drop down menus. This took a long time on large assemblies. On Verb's large assembly, it looks like it took about a minute to go through every single component in the assembly, and I called this method several times needlessly.

I addressed in this problem two ways. First, I consolidated these calls to only when the user clicks export. Second, I reduced the recursion to only the top level components. This should make the exporting much snappier.