### PR TITLE
Check config version

### DIFF
--- a/SW2URDF/URDFExporter/Serialization.cs
+++ b/SW2URDF/URDFExporter/Serialization.cs
@@ -43,8 +43,6 @@ namespace SW2URDF
 
         public const string V1_URDF_CONFIGURATION_ATTRIBUTE_NAME = "URDF Export Configuration";
 
-        public const double MIN_LOAD_CSV_VERSION = 1.3;
-
         #region Public Methods
 
         /// <summary>
@@ -115,13 +113,6 @@ namespace SW2URDF
                     SaveDataToModelDoc(swApp, model, newData);
                 }
             }
-        }
-
-        public static double GetConfigurationVersion(SldWorks swApp, ModelDoc2 model, out bool error)
-        {
-            string data = GetConfigTreeData(model, out double configVersion);
-            error = (data == null || configVersion <= 0.0);
-            return configVersion;
         }
 
         #endregion Public Methods

--- a/SW2URDF/URDFExporter/URDFExporterPMExtension.cs
+++ b/SW2URDF/URDFExporter/URDFExporterPMExtension.cs
@@ -579,10 +579,9 @@ namespace SW2URDF
             SetConfigTree(baseNode);
 
             IPropertyManagerPageControl loadConfigurationControl = (IPropertyManagerPageControl)PMButtonLoad;
-            double configVersion = Serialization.GetConfigurationVersion(swApp, ActiveSWModel, out abortProcess);
             Link baseLink = baseNode.GetLink();
 
-            if (configVersion < Serialization.MIN_LOAD_CSV_VERSION || !baseLink.AreRequiredFieldsSatisfied())
+            if (!baseLink.AreRequiredFieldsSatisfied())
             {
                 loadConfigurationControl.Enabled = false;
                 loadConfigurationControl.Tip = "This feature will be available once you have " +


### PR DESCRIPTION
Because the old configuration version did not store all the values computed during the exporting process, it added a complication to the merge from CSV feature. Basically, a lot of values would be 0 in the original configuration and loading from a CSV file that did not include those links would cause the exporter to skip recalculating them. 

This pull request adds a check to ensure that the configuration in the assembly had been exported before. If all the values have been calculated, then the button will be enabled. Otherwise a helpful tool tip is provided. I also needed to add-in an override for the AreRequiredFieldsSatisfied method in the Link object specifically.