### PR TITLE
Adding MessageBox Interface for mocking

### DIFF
--- a/SW2URDF.sln
+++ b/SW2URDF.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 15.0.28307.168
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SW2URDF", "SW2URDF\SW2URDF.csproj", "{473A16EC-06E9-4C08-B6EF-9AF0036B69E6}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TestRunner", "TestRunner\TestRunner.csproj", "{4BCA2D3C-ED8B-40F2-9B9E-CB02F64498FB}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -13,6 +15,9 @@ Global
 		Release|Any CPU = Release|Any CPU
 		Release|x64 = Release|x64
 		Release|x86 = Release|x86
+		Test Release|Any CPU = Test Release|Any CPU
+		Test Release|x64 = Test Release|x64
+		Test Release|x86 = Test Release|x86
 		Test|Any CPU = Test|Any CPU
 		Test|x64 = Test|x64
 		Test|x86 = Test|x86
@@ -30,12 +35,42 @@ Global
 		{473A16EC-06E9-4C08-B6EF-9AF0036B69E6}.Release|x64.Build.0 = Release|x64
 		{473A16EC-06E9-4C08-B6EF-9AF0036B69E6}.Release|x86.ActiveCfg = Release|x86
 		{473A16EC-06E9-4C08-B6EF-9AF0036B69E6}.Release|x86.Build.0 = Release|x86
+		{473A16EC-06E9-4C08-B6EF-9AF0036B69E6}.Test Release|Any CPU.ActiveCfg = Release|Any CPU
+		{473A16EC-06E9-4C08-B6EF-9AF0036B69E6}.Test Release|Any CPU.Build.0 = Release|Any CPU
+		{473A16EC-06E9-4C08-B6EF-9AF0036B69E6}.Test Release|x64.ActiveCfg = Release|x64
+		{473A16EC-06E9-4C08-B6EF-9AF0036B69E6}.Test Release|x64.Build.0 = Release|x64
+		{473A16EC-06E9-4C08-B6EF-9AF0036B69E6}.Test Release|x86.ActiveCfg = Release|x86
+		{473A16EC-06E9-4C08-B6EF-9AF0036B69E6}.Test Release|x86.Build.0 = Release|x86
 		{473A16EC-06E9-4C08-B6EF-9AF0036B69E6}.Test|Any CPU.ActiveCfg = Release|Any CPU
 		{473A16EC-06E9-4C08-B6EF-9AF0036B69E6}.Test|Any CPU.Build.0 = Release|Any CPU
 		{473A16EC-06E9-4C08-B6EF-9AF0036B69E6}.Test|x64.ActiveCfg = Debug|x64
 		{473A16EC-06E9-4C08-B6EF-9AF0036B69E6}.Test|x64.Build.0 = Debug|x64
 		{473A16EC-06E9-4C08-B6EF-9AF0036B69E6}.Test|x86.ActiveCfg = Release|x86
 		{473A16EC-06E9-4C08-B6EF-9AF0036B69E6}.Test|x86.Build.0 = Release|x86
+		{4BCA2D3C-ED8B-40F2-9B9E-CB02F64498FB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4BCA2D3C-ED8B-40F2-9B9E-CB02F64498FB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4BCA2D3C-ED8B-40F2-9B9E-CB02F64498FB}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{4BCA2D3C-ED8B-40F2-9B9E-CB02F64498FB}.Debug|x64.Build.0 = Debug|Any CPU
+		{4BCA2D3C-ED8B-40F2-9B9E-CB02F64498FB}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{4BCA2D3C-ED8B-40F2-9B9E-CB02F64498FB}.Debug|x86.Build.0 = Debug|Any CPU
+		{4BCA2D3C-ED8B-40F2-9B9E-CB02F64498FB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4BCA2D3C-ED8B-40F2-9B9E-CB02F64498FB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4BCA2D3C-ED8B-40F2-9B9E-CB02F64498FB}.Release|x64.ActiveCfg = Release|Any CPU
+		{4BCA2D3C-ED8B-40F2-9B9E-CB02F64498FB}.Release|x64.Build.0 = Release|Any CPU
+		{4BCA2D3C-ED8B-40F2-9B9E-CB02F64498FB}.Release|x86.ActiveCfg = Release|Any CPU
+		{4BCA2D3C-ED8B-40F2-9B9E-CB02F64498FB}.Release|x86.Build.0 = Release|Any CPU
+		{4BCA2D3C-ED8B-40F2-9B9E-CB02F64498FB}.Test Release|Any CPU.ActiveCfg = Debug|Any CPU
+		{4BCA2D3C-ED8B-40F2-9B9E-CB02F64498FB}.Test Release|Any CPU.Build.0 = Debug|Any CPU
+		{4BCA2D3C-ED8B-40F2-9B9E-CB02F64498FB}.Test Release|x64.ActiveCfg = Release|Any CPU
+		{4BCA2D3C-ED8B-40F2-9B9E-CB02F64498FB}.Test Release|x64.Build.0 = Release|Any CPU
+		{4BCA2D3C-ED8B-40F2-9B9E-CB02F64498FB}.Test Release|x86.ActiveCfg = Debug|Any CPU
+		{4BCA2D3C-ED8B-40F2-9B9E-CB02F64498FB}.Test Release|x86.Build.0 = Debug|Any CPU
+		{4BCA2D3C-ED8B-40F2-9B9E-CB02F64498FB}.Test|Any CPU.ActiveCfg = Debug|Any CPU
+		{4BCA2D3C-ED8B-40F2-9B9E-CB02F64498FB}.Test|Any CPU.Build.0 = Debug|Any CPU
+		{4BCA2D3C-ED8B-40F2-9B9E-CB02F64498FB}.Test|x64.ActiveCfg = Debug|Any CPU
+		{4BCA2D3C-ED8B-40F2-9B9E-CB02F64498FB}.Test|x64.Build.0 = Debug|Any CPU
+		{4BCA2D3C-ED8B-40F2-9B9E-CB02F64498FB}.Test|x86.ActiveCfg = Debug|Any CPU
+		{4BCA2D3C-ED8B-40F2-9B9E-CB02F64498FB}.Test|x86.Build.0 = Debug|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/SW2URDF/SW2URDF.csproj
+++ b/SW2URDF/SW2URDF.csproj
@@ -225,6 +225,8 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Legacy\SerialNode.cs" />
+    <Compile Include="UI\IMessageBox.cs" />
+    <Compile Include="UI\MessageBoxHelper.cs" />
     <Compile Include="URDF\Mimic.cs" />
     <Compile Include="Utilities\Logger.cs" />
     <Compile Include="Properties\Resources.Designer.cs">

--- a/SW2URDF/UI/IMessageBox.cs
+++ b/SW2URDF/UI/IMessageBox.cs
@@ -1,0 +1,10 @@
+﻿using System.Windows;
+
+namespace SW2URDF.UI
+{
+    public interface IMessageBox
+    {
+        MessageBoxResult Show(string message);
+        MessageBoxResult Show(string message, string caption, MessageBoxButton buttons);
+    }
+}

--- a/SW2URDF/UI/MessageBoxHelper.cs
+++ b/SW2URDF/UI/MessageBoxHelper.cs
@@ -1,0 +1,18 @@
+﻿
+using System.Windows;
+
+namespace SW2URDF.UI
+{
+    public class MessageBoxHelper : IMessageBox
+    {
+        MessageBoxResult IMessageBox.Show(string message)
+        {
+            return MessageBox.Show(message);
+        }
+
+        MessageBoxResult IMessageBox.Show(string message, string caption, MessageBoxButton buttons)
+        {
+            return MessageBox.Show(message, caption, buttons);
+        }
+    }
+}

--- a/SW2URDF/URDFExport/URDFPackage.cs
+++ b/SW2URDF/URDFExport/URDFPackage.cs
@@ -20,6 +20,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
+using SW2URDF.UI;
 using System;
 using System.IO;
 
@@ -27,6 +28,7 @@ namespace SW2URDF.URDFExport
 {
     public class URDFPackage
     {
+        public static IMessageBox MessageBox = new MessageBoxHelper();
         public string PackageName { get; }
 
         public string PackageDirectory { get; }
@@ -69,7 +71,7 @@ namespace SW2URDF.URDFExport
 
         public void CreateDirectories()
         {
-            System.Windows.Forms.MessageBox.Show("Creating URDF Package \"" +
+            MessageBox.Show("Creating URDF Package \"" +
                 PackageName + "\" at:\n" + WindowsPackageDirectory);
             if (!Directory.Exists(WindowsPackageDirectory))
             {


### PR DESCRIPTION
This adds the capabilities of mocking the MessageBox that gets shown at many different points in the program execution. This allows the testing framework to evaluate the MessageBox functionality without actually showing it when running tests.