### PR TITLE
Addressing issue #63, adds quotes around prebuild event

### DIFF
--- a/SW2URDF/SW2URDF.csproj
+++ b/SW2URDF/SW2URDF.csproj
@@ -466,7 +466,7 @@
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PreBuildEvent>C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe -ExecutionPolicy Bypass -File $(SolutionDir)scripts\UpdateVersionInfo.ps1 --filename $(ProjectDir)Versioning\VersionInfo.cs</PreBuildEvent>
+    <PreBuildEvent>"C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe" -ExecutionPolicy Bypass -File "$(SolutionDir)scripts\UpdateVersionInfo.ps1" --filename "$(ProjectDir)Versioning\VersionInfo.cs"</PreBuildEvent>
     <PostBuildEvent>
 :REGISTRATION
 IF "$(TargetFrameworkVersion)"=="v4.5.2" GOTO NET40


### PR DESCRIPTION
Addressing issue #63. Without quotes it failed when spaces were in any directory in the solution path.