### PR TITLE
include package version attribute

### DIFF
--- a/SW2URDF/URDF/PackageXMLWriter.cs
+++ b/SW2URDF/URDF/PackageXMLWriter.cs
@@ -62,6 +62,7 @@ namespace SW2URDF.URDF
             XmlWriter writer = mWriter.writer;
             writer.WriteStartDocument();
             writer.WriteStartElement("package");
+            writer.WriteAttributeString("format", "2");
 
             description.WriteElement(writer);
 


### PR DESCRIPTION
Melodic and Gazebo V9 both seem to require the package version to be explicitly defined or ROS building fails