### PR TITLE
Important issue with package.xml

### DIFF
--- a/SW2URDF/URDFWriter.cs
+++ b/SW2URDF/URDFWriter.cs
@@ -15,6 +15,7 @@ using System.Windows.Forms;
 using System.Xml;
 using System.Text;
 
+
 namespace SW2URDF
 {
     public class URDFWriter


### PR DESCRIPTION
Quick heads up: This PR should not be merged into the master branch since it's just a way of contacting you. I recently tried using your Plugin and discovered 2 *very* important issues:
the package.xml in my case didn't include a `format="2"` and so when I tried running catkin_make, it gave me an error about the `depend` tags. As there's barely any documentation about this, it was fairly hard to find something about this so I want to prevent other people from having this issue.
The update is described here: http://mirror-eu.docs.ros.org/jade/api/catkin/html/howto/format2/migrating_from_format_1.html
I fixed this by simply adding the tag specified in the docs but that's generally a major issue. The other problem I had was about the naming convention catkin accepts: I would strongly encourage the developers run the input file names (the Solidworks assembly file) through a naming filter and thus eliminate any problems. Just use a `ToLower()` and remove any whitespaces and the plugin just got a lot more user-friendly. I apologize for this bad way of opening this issue but I simply didn't have the time to find where the XML writer is working in the background. I really hope this helps the users of this plugin and as I think it's not hard to fix, I would love to see an update of the plugin.