### PR TITLE
Switched to joint_state_publisher_gui from joint_state_publisher as t…

### DIFF
--- a/SW2URDF/ROS/ROSFiles.cs
+++ b/SW2URDF/ROS/ROSFiles.cs
@@ -234,10 +234,8 @@ namespace SW2URDF.ROS
             elements = new List<LaunchElement>
             {
                 new LaunchArg("model"),
-                new LaunchArg("gui", "False"),
                 new LaunchParam("robot_description", "", "$(find " + package + ")/urdf/" + robotURDF),
-                new LaunchParam("use_gui", "$(arg gui)"),
-                new LaunchNode("joint_state_publisher", "joint_state_publisher", "joint_state_publisher"),
+                new LaunchNode("joint_state_publisher_gui", "joint_state_publisher_gui", "joint_state_publisher_gui"),
                 new LaunchNode("robot_state_publisher", "robot_state_publisher", "state_publisher"),
                 new LaunchNode("rviz", "rviz", "rviz", "-d $(find " + package + ")/urdf.rviz")
             };

--- a/SW2URDF/ROS/ROSFiles.cs
+++ b/SW2URDF/ROS/ROSFiles.cs
@@ -236,7 +236,7 @@ namespace SW2URDF.ROS
                 new LaunchArg("model"),
                 new LaunchParam("robot_description", "", "$(find " + package + ")/urdf/" + robotURDF),
                 new LaunchNode("joint_state_publisher_gui", "joint_state_publisher_gui", "joint_state_publisher_gui"),
-                new LaunchNode("robot_state_publisher", "robot_state_publisher", "state_publisher"),
+                new LaunchNode("robot_state_publisher", "robot_state_publisher", "robot_state_publisher"),
                 new LaunchNode("rviz", "rviz", "rviz", "-d $(find " + package + ")/urdf.rviz")
             };
         }

--- a/SW2URDF/URDF/PackageXMLWriter.cs
+++ b/SW2URDF/URDF/PackageXMLWriter.cs
@@ -50,7 +50,7 @@ namespace SW2URDF.URDF
             dependencies = new Dependencies(
                 new string[] { "catkin" },
                 new string[] {
-                    "roslaunch", "robot_state_publisher", "rviz", "joint_state_publisher", "gazebo" });
+                    "roslaunch", "robot_state_publisher", "rviz", "joint_state_publisher_gui", "gazebo" });
 
             author = new Author("TODO");
 

--- a/examples/3_DOF_ARM/3_DOF_ARM_description/launch/display.launch
+++ b/examples/3_DOF_ARM/3_DOF_ARM_description/launch/display.launch
@@ -11,7 +11,7 @@
   <node
     name="robot_state_publisher"
     pkg="robot_state_publisher"
-    type="state_publisher" />
+    type="robot_state_publisher" />
   <node
     name="rviz"
     pkg="rviz"

--- a/examples/3_DOF_ARM/3_DOF_ARM_description/launch/display.launch
+++ b/examples/3_DOF_ARM/3_DOF_ARM_description/launch/display.launch
@@ -1,19 +1,13 @@
 <launch>
   <arg
     name="model" />
-  <arg
-    name="gui"
-    default="False" />
   <param
     name="robot_description"
     textfile="$(find 3_DOF_ARM_description)/urdf/3_DOF_ARM_description.urdf" />
-  <param
-    name="use_gui"
-    value="$(arg gui)" />
   <node
-    name="joint_state_publisher"
-    pkg="joint_state_publisher"
-    type="joint_state_publisher" />
+    name="joint_state_publisher_gui"
+    pkg="joint_state_publisher_gui"
+    type="joint_state_publisher_gui" />
   <node
     name="robot_state_publisher"
     pkg="robot_state_publisher"

--- a/examples/3_DOF_ARM/3_DOF_ARM_description/package.xml
+++ b/examples/3_DOF_ARM/3_DOF_ARM_description/package.xml
@@ -13,7 +13,7 @@ for 3_DOF_ARM_description robot</p>
   <depend>roslaunch</depend>
   <depend>robot_state_publisher</depend>
   <depend>rviz</depend>
-  <depend>joint_state_publisher</depend>
+  <depend>joint_state_publisher_gui</depend>
   <depend>gazebo</depend>
   <export>
     <architecture_independent />

--- a/examples/4_WHEELER/4_WHEELER_description/launch/display.launch
+++ b/examples/4_WHEELER/4_WHEELER_description/launch/display.launch
@@ -11,7 +11,7 @@
   <node
     name="robot_state_publisher"
     pkg="robot_state_publisher"
-    type="state_publisher" />
+    type="robot_state_publisher" />
   <node
     name="rviz"
     pkg="rviz"

--- a/examples/4_WHEELER/4_WHEELER_description/launch/display.launch
+++ b/examples/4_WHEELER/4_WHEELER_description/launch/display.launch
@@ -11,9 +11,9 @@
     name="use_gui"
     value="$(arg gui)" />
   <node
-    name="joint_state_publisher"
-    pkg="joint_state_publisher"
-    type="joint_state_publisher" />
+    name="joint_state_publisher_gui"
+    pkg="joint_state_publisher_gui"
+    type="joint_state_publisher_gui" />
   <node
     name="robot_state_publisher"
     pkg="robot_state_publisher"

--- a/examples/4_WHEELER/4_WHEELER_description/launch/display.launch
+++ b/examples/4_WHEELER/4_WHEELER_description/launch/display.launch
@@ -1,15 +1,9 @@
 <launch>
   <arg
     name="model" />
-  <arg
-    name="gui"
-    default="False" />
   <param
     name="robot_description"
     textfile="$(find 4_WHEELER_description)/urdf/4_WHEELER_description.urdf" />
-  <param
-    name="use_gui"
-    value="$(arg gui)" />
   <node
     name="joint_state_publisher_gui"
     pkg="joint_state_publisher_gui"

--- a/examples/4_WHEELER/4_WHEELER_description/package.xml
+++ b/examples/4_WHEELER/4_WHEELER_description/package.xml
@@ -13,7 +13,7 @@ for 4_WHEELER_description robot</p>
   <depend>roslaunch</depend>
   <depend>robot_state_publisher</depend>
   <depend>rviz</depend>
-  <depend>joint_state_publisher</depend>
+  <depend>joint_state_publisher_gui</depend>
   <depend>gazebo</depend>
   <export>
     <architecture_independent />

--- a/examples/ORIGINAL_3_DOF_ARM/ORIGINAL_3_DOF_ARM_description/launch/display.launch
+++ b/examples/ORIGINAL_3_DOF_ARM/ORIGINAL_3_DOF_ARM_description/launch/display.launch
@@ -11,9 +11,9 @@
     name="use_gui"
     value="$(arg gui)" />
   <node
-    name="joint_state_publisher"
-    pkg="joint_state_publisher"
-    type="joint_state_publisher" />
+    name="joint_state_publisher_gui"
+    pkg="joint_state_publisher_gui"
+    type="joint_state_publisher_gui" />
   <node
     name="robot_state_publisher"
     pkg="robot_state_publisher"


### PR DESCRIPTION
…he arg use_gui is no longer available.

This was changed for Noetic here: https://github.com/ros/joint_state_publisher/pull/34/files 
Also, here is the warning:
```
[WARN] [1585686334.832882]: The 'use_gui' parameter was specified, which is deprecated.  We'll attempt to find and run the GUI, but if this fails you should install the 'joint_state_publisher_gui' package instead and run that.  This backwards compatibility option will be removed in Noetic.
```