### PR TITLE
Enabled to export mesh as 3dxml format

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,15 @@ See the [ROS Wiki](http://wiki.ros.org/sw_urdf_exporter) and associated [tutoria
     1. Ensure `Configuration:` is set to `Debug`
     1. Ensure `Start external program:` is pointing to the SolidWorks executable. For example `C:\Program Files\SOLIDWORKS Corp\SOLIDWORKS\SLDWORKS.exe`
 
+## Converting mesh format from 3dxml to dae
+
+Executing the following command will convert the format of the exported mesh from 3DXML to DAE, and rewrite the URDF, allowing you to display colored meshes in visualization tools like RViz:
+
+```bash
+pip3 install scikit-robot -U
+convert-urdf-mesh <URDF_PATH> --output <OUTPUT_URDF_PATH>
+```
+
 ### Trouble Shooting
 
 1. `AxImp.exe` error - Check the installation of the .Net Tools. If there is no error, install the Windows 10 SDK.

--- a/SW2URDF/Test/TestExportHelper.cs
+++ b/SW2URDF/Test/TestExportHelper.cs
@@ -14,10 +14,13 @@ namespace SW2URDF.Test
         }
 
         [Theory]
-        [InlineData("3_DOF_ARM", 4)]
-        [InlineData("4_WHEELER", 5)]
-        [InlineData("ORIGINAL_3_DOF_ARM", 4)]
-        public void TestExportRobot(string modelName, int expNumLinks)
+        [InlineData("3_DOF_ARM", 4, MeshExportFormat.STL)]
+        [InlineData("4_WHEELER", 5, MeshExportFormat.STL)]
+        [InlineData("ORIGINAL_3_DOF_ARM", 4, MeshExportFormat.STL)]
+        [InlineData("3_DOF_ARM", 4, MeshExportFormat.THREEDXML)]
+        [InlineData("4_WHEELER", 5, MeshExportFormat.THREEDXML)]
+        [InlineData("ORIGINAL_3_DOF_ARM", 4, MeshExportFormat.THREEDXML)]
+        public void TestExportRobot(string modelName, int expNumLinks, MeshExportFormat meshExportFormat)
         {
             ModelDoc2 doc = OpenSWDocument(modelName);
             ExportHelper helper = new ExportHelper(SwApp);
@@ -28,7 +31,7 @@ namespace SW2URDF.Test
             LinkNode baseNode = ConfigurationSerialization.LoadBaseNodeFromModel(doc, out bool error);
             Assert.False(error);
             helper.CreateRobotFromTreeView(baseNode);
-            helper.ExportRobot(true);
+            helper.ExportRobot(true, meshExportFormat);
             Assert.NotNull(helper.URDFRobot);
             Assert.Equal(expNumLinks, CommonSwOperations.GetCount(helper.URDFRobot.BaseLink));
             Assert.True(SwApp.CloseAllDocuments(true));

--- a/SW2URDF/UI/AssemblyExportForm.Designer.cs
+++ b/SW2URDF/UI/AssemblyExportForm.Designer.cs
@@ -68,6 +68,9 @@
             this.label50 = new System.Windows.Forms.Label();
             this.textBoxMass = new System.Windows.Forms.TextBox();
             this.groupBox4 = new System.Windows.Forms.GroupBox();
+            this.groupBox1 = new System.Windows.Forms.GroupBox();
+            this.radioButton3dxml = new System.Windows.Forms.RadioButton();
+            this.radioButtonStl = new System.Windows.Forms.RadioButton();
             this.radioButtonFine = new System.Windows.Forms.RadioButton();
             this.radioButtonCourse = new System.Windows.Forms.RadioButton();
             this.label10 = new System.Windows.Forms.Label();
@@ -183,6 +186,7 @@
             this.panelLinkProperties.SuspendLayout();
             this.groupBox5.SuspendLayout();
             this.groupBox4.SuspendLayout();
+            this.groupBox1.SuspendLayout();
             this.SuspendLayout();
             // 
             // panelLinkProperties
@@ -199,17 +203,17 @@
             this.panelLinkProperties.Dock = System.Windows.Forms.DockStyle.Fill;
             this.panelLinkProperties.Location = new System.Drawing.Point(0, 0);
             this.panelLinkProperties.Name = "panelLinkProperties";
-            this.panelLinkProperties.Size = new System.Drawing.Size(1073, 687);
+            this.panelLinkProperties.Size = new System.Drawing.Size(1073, 634);
             this.panelLinkProperties.TabIndex = 222;
             this.panelLinkProperties.Visible = false;
             // 
             // buttonLinksExportUrdfOnly
             // 
             this.buttonLinksExportUrdfOnly.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-            this.buttonLinksExportUrdfOnly.Location = new System.Drawing.Point(759, 653);
+            this.buttonLinksExportUrdfOnly.Location = new System.Drawing.Point(759, 603);
             this.buttonLinksExportUrdfOnly.Margin = new System.Windows.Forms.Padding(2);
             this.buttonLinksExportUrdfOnly.Name = "buttonLinksExportUrdfOnly";
-            this.buttonLinksExportUrdfOnly.Size = new System.Drawing.Size(150, 23);
+            this.buttonLinksExportUrdfOnly.Size = new System.Drawing.Size(150, 21);
             this.buttonLinksExportUrdfOnly.TabIndex = 94;
             this.buttonLinksExportUrdfOnly.Text = "Export URDF Only...";
             this.buttonLinksExportUrdfOnly.UseVisualStyleBackColor = true;
@@ -218,9 +222,9 @@
             // label2
             // 
             this.label2.AutoSize = true;
-            this.label2.Location = new System.Drawing.Point(22, 34);
+            this.label2.Location = new System.Drawing.Point(22, 31);
             this.label2.Name = "label2";
-            this.label2.Size = new System.Drawing.Size(282, 13);
+            this.label2.Size = new System.Drawing.Size(308, 12);
             this.label2.TabIndex = 93;
             this.label2.Text = "Use this page to make any changes to the links\' properties";
             // 
@@ -228,7 +232,7 @@
             // 
             this.label5.AutoSize = true;
             this.label5.Font = new System.Drawing.Font("Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.label5.Location = new System.Drawing.Point(12, 9);
+            this.label5.Location = new System.Drawing.Point(12, 8);
             this.label5.Name = "label5";
             this.label5.Size = new System.Drawing.Size(193, 17);
             this.label5.TabIndex = 92;
@@ -237,9 +241,9 @@
             // buttonLinksFinish
             // 
             this.buttonLinksFinish.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-            this.buttonLinksFinish.Location = new System.Drawing.Point(914, 653);
+            this.buttonLinksFinish.Location = new System.Drawing.Point(914, 603);
             this.buttonLinksFinish.Name = "buttonLinksFinish";
-            this.buttonLinksFinish.Size = new System.Drawing.Size(150, 23);
+            this.buttonLinksFinish.Size = new System.Drawing.Size(150, 21);
             this.buttonLinksFinish.TabIndex = 91;
             this.buttonLinksFinish.Text = "Export URDF and Meshes...";
             this.buttonLinksFinish.UseVisualStyleBackColor = true;
@@ -248,9 +252,9 @@
             // buttonLinksPrevious
             // 
             this.buttonLinksPrevious.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-            this.buttonLinksPrevious.Location = new System.Drawing.Point(509, 653);
+            this.buttonLinksPrevious.Location = new System.Drawing.Point(509, 603);
             this.buttonLinksPrevious.Name = "buttonLinksPrevious";
-            this.buttonLinksPrevious.Size = new System.Drawing.Size(75, 23);
+            this.buttonLinksPrevious.Size = new System.Drawing.Size(75, 21);
             this.buttonLinksPrevious.TabIndex = 90;
             this.buttonLinksPrevious.Text = "Previous";
             this.buttonLinksPrevious.UseVisualStyleBackColor = true;
@@ -259,9 +263,9 @@
             // buttonLinksCancel
             // 
             this.buttonLinksCancel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-            this.buttonLinksCancel.Location = new System.Drawing.Point(12, 653);
+            this.buttonLinksCancel.Location = new System.Drawing.Point(12, 603);
             this.buttonLinksCancel.Name = "buttonLinksCancel";
-            this.buttonLinksCancel.Size = new System.Drawing.Size(75, 23);
+            this.buttonLinksCancel.Size = new System.Drawing.Size(75, 21);
             this.buttonLinksCancel.TabIndex = 89;
             this.buttonLinksCancel.Text = "Cancel";
             this.buttonLinksCancel.UseVisualStyleBackColor = true;
@@ -300,9 +304,9 @@
             this.groupBox5.Controls.Add(this.label50);
             this.groupBox5.Controls.Add(this.textBoxMass);
             this.groupBox5.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.groupBox5.Location = new System.Drawing.Point(494, 87);
+            this.groupBox5.Location = new System.Drawing.Point(494, 80);
             this.groupBox5.Name = "groupBox5";
-            this.groupBox5.Size = new System.Drawing.Size(568, 195);
+            this.groupBox5.Size = new System.Drawing.Size(568, 180);
             this.groupBox5.TabIndex = 71;
             this.groupBox5.TabStop = false;
             // 
@@ -318,21 +322,21 @@
             // 
             // textBoxIxx
             // 
-            this.textBoxIxx.Location = new System.Drawing.Point(273, 58);
+            this.textBoxIxx.Location = new System.Drawing.Point(273, 54);
             this.textBoxIxx.Name = "textBoxIxx";
             this.textBoxIxx.Size = new System.Drawing.Size(66, 20);
             this.textBoxIxx.TabIndex = 7;
             // 
             // textBoxIxz
             // 
-            this.textBoxIxz.Location = new System.Drawing.Point(472, 58);
+            this.textBoxIxz.Location = new System.Drawing.Point(472, 54);
             this.textBoxIxz.Name = "textBoxIxz";
             this.textBoxIxz.Size = new System.Drawing.Size(66, 20);
             this.textBoxIxz.TabIndex = 9;
             // 
             // textBoxInertialOriginX
             // 
-            this.textBoxInertialOriginX.Location = new System.Drawing.Point(44, 58);
+            this.textBoxInertialOriginX.Location = new System.Drawing.Point(44, 54);
             this.textBoxInertialOriginX.Name = "textBoxInertialOriginX";
             this.textBoxInertialOriginX.Size = new System.Drawing.Size(66, 20);
             this.textBoxInertialOriginX.TabIndex = 3;
@@ -340,7 +344,7 @@
             // label16
             // 
             this.label16.AutoSize = true;
-            this.label16.Location = new System.Drawing.Point(118, 63);
+            this.label16.Location = new System.Drawing.Point(118, 58);
             this.label16.Name = "label16";
             this.label16.Size = new System.Drawing.Size(25, 13);
             this.label16.TabIndex = 27;
@@ -348,7 +352,7 @@
             // 
             // textBoxInertialOriginYaw
             // 
-            this.textBoxInertialOriginYaw.Location = new System.Drawing.Point(150, 110);
+            this.textBoxInertialOriginYaw.Location = new System.Drawing.Point(150, 102);
             this.textBoxInertialOriginYaw.Name = "textBoxInertialOriginYaw";
             this.textBoxInertialOriginYaw.Size = new System.Drawing.Size(66, 20);
             this.textBoxInertialOriginYaw.TabIndex = 32;
@@ -356,7 +360,7 @@
             // label11
             // 
             this.label11.AutoSize = true;
-            this.label11.Location = new System.Drawing.Point(447, 58);
+            this.label11.Location = new System.Drawing.Point(447, 54);
             this.label11.Name = "label11";
             this.label11.Size = new System.Drawing.Size(19, 13);
             this.label11.TabIndex = 16;
@@ -365,7 +369,7 @@
             // label12
             // 
             this.label12.AutoSize = true;
-            this.label12.Location = new System.Drawing.Point(7, 161);
+            this.label12.Location = new System.Drawing.Point(7, 149);
             this.label12.Name = "label12";
             this.label12.Size = new System.Drawing.Size(53, 13);
             this.label12.TabIndex = 13;
@@ -373,14 +377,14 @@
             // 
             // textBoxIyy
             // 
-            this.textBoxIyy.Location = new System.Drawing.Point(369, 84);
+            this.textBoxIyy.Location = new System.Drawing.Point(369, 78);
             this.textBoxIyy.Name = "textBoxIyy";
             this.textBoxIyy.Size = new System.Drawing.Size(66, 20);
             this.textBoxIyy.TabIndex = 10;
             // 
             // textBoxInertialOriginPitch
             // 
-            this.textBoxInertialOriginPitch.Location = new System.Drawing.Point(150, 84);
+            this.textBoxInertialOriginPitch.Location = new System.Drawing.Point(150, 78);
             this.textBoxInertialOriginPitch.Name = "textBoxInertialOriginPitch";
             this.textBoxInertialOriginPitch.Size = new System.Drawing.Size(66, 20);
             this.textBoxInertialOriginPitch.TabIndex = 31;
@@ -388,7 +392,7 @@
             // label13
             // 
             this.label13.AutoSize = true;
-            this.label13.Location = new System.Drawing.Point(26, 58);
+            this.label13.Location = new System.Drawing.Point(26, 54);
             this.label13.Name = "label13";
             this.label13.Size = new System.Drawing.Size(12, 13);
             this.label13.TabIndex = 20;
@@ -397,7 +401,7 @@
             // label14
             // 
             this.label14.AutoSize = true;
-            this.label14.Location = new System.Drawing.Point(248, 58);
+            this.label14.Location = new System.Drawing.Point(248, 54);
             this.label14.Name = "label14";
             this.label14.Size = new System.Drawing.Size(19, 13);
             this.label14.TabIndex = 14;
@@ -405,14 +409,14 @@
             // 
             // textBoxInertialOriginRoll
             // 
-            this.textBoxInertialOriginRoll.Location = new System.Drawing.Point(150, 58);
+            this.textBoxInertialOriginRoll.Location = new System.Drawing.Point(150, 54);
             this.textBoxInertialOriginRoll.Name = "textBoxInertialOriginRoll";
             this.textBoxInertialOriginRoll.Size = new System.Drawing.Size(66, 20);
             this.textBoxInertialOriginRoll.TabIndex = 30;
             // 
             // textBoxInertialOriginY
             // 
-            this.textBoxInertialOriginY.Location = new System.Drawing.Point(44, 84);
+            this.textBoxInertialOriginY.Location = new System.Drawing.Point(44, 78);
             this.textBoxInertialOriginY.Name = "textBoxInertialOriginY";
             this.textBoxInertialOriginY.Size = new System.Drawing.Size(66, 20);
             this.textBoxInertialOriginY.TabIndex = 4;
@@ -420,7 +424,7 @@
             // label17
             // 
             this.label17.AutoSize = true;
-            this.label17.Location = new System.Drawing.Point(26, 84);
+            this.label17.Location = new System.Drawing.Point(26, 78);
             this.label17.Name = "label17";
             this.label17.Size = new System.Drawing.Size(12, 13);
             this.label17.TabIndex = 21;
@@ -429,7 +433,7 @@
             // label18
             // 
             this.label18.AutoSize = true;
-            this.label18.Location = new System.Drawing.Point(447, 115);
+            this.label18.Location = new System.Drawing.Point(447, 106);
             this.label18.Name = "label18";
             this.label18.Size = new System.Drawing.Size(19, 13);
             this.label18.TabIndex = 19;
@@ -437,7 +441,7 @@
             // 
             // textBoxIyz
             // 
-            this.textBoxIyz.Location = new System.Drawing.Point(472, 84);
+            this.textBoxIyz.Location = new System.Drawing.Point(472, 78);
             this.textBoxIyz.Name = "textBoxIyz";
             this.textBoxIyz.Size = new System.Drawing.Size(66, 20);
             this.textBoxIyz.TabIndex = 11;
@@ -445,7 +449,7 @@
             // label36
             // 
             this.label36.AutoSize = true;
-            this.label36.Location = new System.Drawing.Point(7, 22);
+            this.label36.Location = new System.Drawing.Point(7, 20);
             this.label36.Name = "label36";
             this.label36.Size = new System.Drawing.Size(51, 13);
             this.label36.TabIndex = 24;
@@ -454,7 +458,7 @@
             // label44
             // 
             this.label44.AutoSize = true;
-            this.label44.Location = new System.Drawing.Point(235, 22);
+            this.label44.Location = new System.Drawing.Point(235, 20);
             this.label44.Name = "label44";
             this.label44.Size = new System.Drawing.Size(144, 13);
             this.label44.TabIndex = 23;
@@ -463,7 +467,7 @@
             // label45
             // 
             this.label45.AutoSize = true;
-            this.label45.Location = new System.Drawing.Point(113, 89);
+            this.label45.Location = new System.Drawing.Point(113, 82);
             this.label45.Name = "label45";
             this.label45.Size = new System.Drawing.Size(31, 13);
             this.label45.TabIndex = 28;
@@ -472,7 +476,7 @@
             // label46
             // 
             this.label46.AutoSize = true;
-            this.label46.Location = new System.Drawing.Point(116, 115);
+            this.label46.Location = new System.Drawing.Point(116, 106);
             this.label46.Name = "label46";
             this.label46.Size = new System.Drawing.Size(28, 13);
             this.label46.TabIndex = 29;
@@ -480,7 +484,7 @@
             // 
             // textBoxInertialOriginZ
             // 
-            this.textBoxInertialOriginZ.Location = new System.Drawing.Point(44, 110);
+            this.textBoxInertialOriginZ.Location = new System.Drawing.Point(44, 102);
             this.textBoxInertialOriginZ.Name = "textBoxInertialOriginZ";
             this.textBoxInertialOriginZ.Size = new System.Drawing.Size(66, 20);
             this.textBoxInertialOriginZ.TabIndex = 5;
@@ -488,7 +492,7 @@
             // label47
             // 
             this.label47.AutoSize = true;
-            this.label47.Location = new System.Drawing.Point(26, 110);
+            this.label47.Location = new System.Drawing.Point(26, 102);
             this.label47.Name = "label47";
             this.label47.Size = new System.Drawing.Size(12, 13);
             this.label47.TabIndex = 22;
@@ -497,7 +501,7 @@
             // label48
             // 
             this.label48.AutoSize = true;
-            this.label48.Location = new System.Drawing.Point(447, 87);
+            this.label48.Location = new System.Drawing.Point(447, 80);
             this.label48.Name = "label48";
             this.label48.Size = new System.Drawing.Size(19, 13);
             this.label48.TabIndex = 18;
@@ -506,7 +510,7 @@
             // label49
             // 
             this.label49.AutoSize = true;
-            this.label49.Location = new System.Drawing.Point(344, 89);
+            this.label49.Location = new System.Drawing.Point(344, 82);
             this.label49.Name = "label49";
             this.label49.Size = new System.Drawing.Size(19, 13);
             this.label49.TabIndex = 17;
@@ -514,14 +518,14 @@
             // 
             // textBoxIxy
             // 
-            this.textBoxIxy.Location = new System.Drawing.Point(369, 58);
+            this.textBoxIxy.Location = new System.Drawing.Point(369, 54);
             this.textBoxIxy.Name = "textBoxIxy";
             this.textBoxIxy.Size = new System.Drawing.Size(66, 20);
             this.textBoxIxy.TabIndex = 8;
             // 
             // textBoxIzz
             // 
-            this.textBoxIzz.Location = new System.Drawing.Point(472, 110);
+            this.textBoxIzz.Location = new System.Drawing.Point(472, 102);
             this.textBoxIzz.Name = "textBoxIzz";
             this.textBoxIzz.Size = new System.Drawing.Size(66, 20);
             this.textBoxIzz.TabIndex = 12;
@@ -529,7 +533,7 @@
             // label50
             // 
             this.label50.AutoSize = true;
-            this.label50.Location = new System.Drawing.Point(344, 58);
+            this.label50.Location = new System.Drawing.Point(344, 54);
             this.label50.Name = "label50";
             this.label50.Size = new System.Drawing.Size(19, 13);
             this.label50.TabIndex = 15;
@@ -537,7 +541,7 @@
             // 
             // textBoxMass
             // 
-            this.textBoxMass.Location = new System.Drawing.Point(65, 161);
+            this.textBoxMass.Location = new System.Drawing.Point(65, 149);
             this.textBoxMass.Name = "textBoxMass";
             this.textBoxMass.Size = new System.Drawing.Size(66, 20);
             this.textBoxMass.TabIndex = 6;
@@ -545,6 +549,7 @@
             // groupBox4
             // 
             this.groupBox4.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.groupBox4.Controls.Add(this.groupBox1);
             this.groupBox4.Controls.Add(this.radioButtonFine);
             this.groupBox4.Controls.Add(this.radioButtonCourse);
             this.groupBox4.Controls.Add(this.label10);
@@ -576,18 +581,52 @@
             this.groupBox4.Controls.Add(this.textBoxVisualOriginY);
             this.groupBox4.Controls.Add(this.label30);
             this.groupBox4.Controls.Add(this.textBoxTexture);
-            this.groupBox4.Location = new System.Drawing.Point(494, 301);
+            this.groupBox4.Location = new System.Drawing.Point(494, 278);
             this.groupBox4.Name = "groupBox4";
-            this.groupBox4.Size = new System.Drawing.Size(568, 330);
+            this.groupBox4.Size = new System.Drawing.Size(568, 305);
             this.groupBox4.TabIndex = 72;
             this.groupBox4.TabStop = false;
+            // 
+            // groupBox1
+            // 
+            this.groupBox1.Controls.Add(this.radioButton3dxml);
+            this.groupBox1.Controls.Add(this.radioButtonStl);
+            this.groupBox1.Location = new System.Drawing.Point(184, 147);
+            this.groupBox1.Name = "groupBox1";
+            this.groupBox1.Size = new System.Drawing.Size(122, 90);
+            this.groupBox1.TabIndex = 74;
+            this.groupBox1.TabStop = false;
+            this.groupBox1.Text = "Mesh Format";
+            // 
+            // radioButton3dxml
+            // 
+            this.radioButton3dxml.AutoSize = true;
+            this.radioButton3dxml.Location = new System.Drawing.Point(11, 54);
+            this.radioButton3dxml.Name = "radioButton3dxml";
+            this.radioButton3dxml.Size = new System.Drawing.Size(90, 16);
+            this.radioButton3dxml.TabIndex = 1;
+            this.radioButton3dxml.TabStop = true;
+            this.radioButton3dxml.Text = "3dxml (color)";
+            this.radioButton3dxml.UseVisualStyleBackColor = true;
+            // 
+            // radioButtonStl
+            // 
+            this.radioButtonStl.AutoSize = true;
+            this.radioButtonStl.Checked = true;
+            this.radioButtonStl.Location = new System.Drawing.Point(11, 24);
+            this.radioButtonStl.Name = "radioButtonStl";
+            this.radioButtonStl.Size = new System.Drawing.Size(104, 16);
+            this.radioButtonStl.TabIndex = 0;
+            this.radioButtonStl.TabStop = true;
+            this.radioButtonStl.Text = "STL (grayscale)";
+            this.radioButtonStl.UseVisualStyleBackColor = true;
             // 
             // radioButtonFine
             // 
             this.radioButtonFine.AutoSize = true;
-            this.radioButtonFine.Location = new System.Drawing.Point(101, 185);
+            this.radioButtonFine.Location = new System.Drawing.Point(101, 171);
             this.radioButtonFine.Name = "radioButtonFine";
-            this.radioButtonFine.Size = new System.Drawing.Size(45, 17);
+            this.radioButtonFine.Size = new System.Drawing.Size(45, 16);
             this.radioButtonFine.TabIndex = 68;
             this.radioButtonFine.Text = "Fine";
             this.radioButtonFine.UseVisualStyleBackColor = true;
@@ -596,9 +635,9 @@
             // 
             this.radioButtonCourse.AutoSize = true;
             this.radioButtonCourse.Checked = true;
-            this.radioButtonCourse.Location = new System.Drawing.Point(20, 185);
+            this.radioButtonCourse.Location = new System.Drawing.Point(20, 171);
             this.radioButtonCourse.Name = "radioButtonCourse";
-            this.radioButtonCourse.Size = new System.Drawing.Size(58, 17);
+            this.radioButtonCourse.Size = new System.Drawing.Size(59, 16);
             this.radioButtonCourse.TabIndex = 67;
             this.radioButtonCourse.TabStop = true;
             this.radioButtonCourse.Text = "Course";
@@ -607,9 +646,9 @@
             // label10
             // 
             this.label10.AutoSize = true;
-            this.label10.Location = new System.Drawing.Point(7, 159);
+            this.label10.Location = new System.Drawing.Point(7, 147);
             this.label10.Name = "label10";
-            this.label10.Size = new System.Drawing.Size(63, 13);
+            this.label10.Size = new System.Drawing.Size(66, 12);
             this.label10.TabIndex = 66;
             this.label10.Text = "Mesh Detail";
             // 
@@ -625,39 +664,39 @@
             // 
             // textBoxVisualOriginZ
             // 
-            this.textBoxVisualOriginZ.Location = new System.Drawing.Point(41, 112);
+            this.textBoxVisualOriginZ.Location = new System.Drawing.Point(41, 103);
             this.textBoxVisualOriginZ.Name = "textBoxVisualOriginZ";
-            this.textBoxVisualOriginZ.Size = new System.Drawing.Size(66, 20);
+            this.textBoxVisualOriginZ.Size = new System.Drawing.Size(66, 19);
             this.textBoxVisualOriginZ.TabIndex = 35;
             // 
             // textBoxVisualOriginYaw
             // 
-            this.textBoxVisualOriginYaw.Location = new System.Drawing.Point(148, 112);
+            this.textBoxVisualOriginYaw.Location = new System.Drawing.Point(148, 103);
             this.textBoxVisualOriginYaw.Name = "textBoxVisualOriginYaw";
-            this.textBoxVisualOriginYaw.Size = new System.Drawing.Size(66, 20);
+            this.textBoxVisualOriginYaw.Size = new System.Drawing.Size(66, 19);
             this.textBoxVisualOriginYaw.TabIndex = 45;
             // 
             // label34
             // 
             this.label34.AutoSize = true;
-            this.label34.Location = new System.Drawing.Point(7, 275);
+            this.label34.Location = new System.Drawing.Point(7, 254);
             this.label34.Name = "label34";
-            this.label34.Size = new System.Drawing.Size(124, 13);
+            this.label34.Size = new System.Drawing.Size(134, 12);
             this.label34.TabIndex = 60;
             this.label34.Text = "Texture (Replaces Color)";
             // 
             // textBoxVisualOriginPitch
             // 
-            this.textBoxVisualOriginPitch.Location = new System.Drawing.Point(148, 86);
+            this.textBoxVisualOriginPitch.Location = new System.Drawing.Point(148, 79);
             this.textBoxVisualOriginPitch.Name = "textBoxVisualOriginPitch";
-            this.textBoxVisualOriginPitch.Size = new System.Drawing.Size(66, 20);
+            this.textBoxVisualOriginPitch.Size = new System.Drawing.Size(66, 19);
             this.textBoxVisualOriginPitch.TabIndex = 44;
             // 
             // buttonTextureBrowse
             // 
-            this.buttonTextureBrowse.Location = new System.Drawing.Point(398, 299);
+            this.buttonTextureBrowse.Location = new System.Drawing.Point(398, 276);
             this.buttonTextureBrowse.Name = "buttonTextureBrowse";
-            this.buttonTextureBrowse.Size = new System.Drawing.Size(75, 23);
+            this.buttonTextureBrowse.Size = new System.Drawing.Size(75, 21);
             this.buttonTextureBrowse.TabIndex = 59;
             this.buttonTextureBrowse.Text = "Browse...";
             this.buttonTextureBrowse.UseVisualStyleBackColor = true;
@@ -666,186 +705,186 @@
             // label28
             // 
             this.label28.AutoSize = true;
-            this.label28.Location = new System.Drawing.Point(7, 218);
+            this.label28.Location = new System.Drawing.Point(7, 201);
             this.label28.Name = "label28";
-            this.label28.Size = new System.Drawing.Size(73, 13);
+            this.label28.Size = new System.Drawing.Size(77, 12);
             this.label28.TabIndex = 47;
             this.label28.Text = "Material name";
             // 
             // textBoxVisualOriginRoll
             // 
-            this.textBoxVisualOriginRoll.Location = new System.Drawing.Point(148, 60);
+            this.textBoxVisualOriginRoll.Location = new System.Drawing.Point(148, 55);
             this.textBoxVisualOriginRoll.Name = "textBoxVisualOriginRoll";
-            this.textBoxVisualOriginRoll.Size = new System.Drawing.Size(66, 20);
+            this.textBoxVisualOriginRoll.Size = new System.Drawing.Size(66, 19);
             this.textBoxVisualOriginRoll.TabIndex = 43;
             // 
             // comboBoxMaterials
             // 
             this.comboBoxMaterials.FormattingEnabled = true;
-            this.comboBoxMaterials.Location = new System.Drawing.Point(16, 244);
+            this.comboBoxMaterials.Location = new System.Drawing.Point(16, 225);
             this.comboBoxMaterials.Name = "comboBoxMaterials";
-            this.comboBoxMaterials.Size = new System.Drawing.Size(121, 21);
+            this.comboBoxMaterials.Size = new System.Drawing.Size(121, 20);
             this.comboBoxMaterials.TabIndex = 48;
             // 
             // label26
             // 
             this.label26.AutoSize = true;
-            this.label26.Location = new System.Drawing.Point(22, 60);
+            this.label26.Location = new System.Drawing.Point(22, 55);
             this.label26.Name = "label26";
-            this.label26.Size = new System.Drawing.Size(12, 13);
+            this.label26.Size = new System.Drawing.Size(11, 12);
             this.label26.TabIndex = 36;
             this.label26.Text = "x";
             // 
             // label20
             // 
             this.label20.AutoSize = true;
-            this.label20.Location = new System.Drawing.Point(114, 112);
+            this.label20.Location = new System.Drawing.Point(114, 103);
             this.label20.Name = "label20";
-            this.label20.Size = new System.Drawing.Size(28, 13);
+            this.label20.Size = new System.Drawing.Size(26, 12);
             this.label20.TabIndex = 42;
             this.label20.Text = "Yaw";
             // 
             // domainUpDownAlpha
             // 
-            this.domainUpDownAlpha.Location = new System.Drawing.Point(412, 141);
+            this.domainUpDownAlpha.Location = new System.Drawing.Point(412, 130);
             this.domainUpDownAlpha.Name = "domainUpDownAlpha";
-            this.domainUpDownAlpha.Size = new System.Drawing.Size(60, 20);
+            this.domainUpDownAlpha.Size = new System.Drawing.Size(60, 19);
             this.domainUpDownAlpha.TabIndex = 57;
             this.domainUpDownAlpha.Text = "1";
             // 
             // label29
             // 
             this.label29.AutoSize = true;
-            this.label29.Location = new System.Drawing.Point(365, 33);
+            this.label29.Location = new System.Drawing.Point(365, 30);
             this.label29.Name = "label29";
-            this.label29.Size = new System.Drawing.Size(31, 13);
+            this.label29.Size = new System.Drawing.Size(32, 12);
             this.label29.TabIndex = 49;
             this.label29.Text = "Color";
             // 
             // label25
             // 
             this.label25.AutoSize = true;
-            this.label25.Location = new System.Drawing.Point(22, 86);
+            this.label25.Location = new System.Drawing.Point(22, 79);
             this.label25.Name = "label25";
-            this.label25.Size = new System.Drawing.Size(12, 13);
+            this.label25.Size = new System.Drawing.Size(11, 12);
             this.label25.TabIndex = 37;
             this.label25.Text = "y";
             // 
             // label21
             // 
             this.label21.AutoSize = true;
-            this.label21.Location = new System.Drawing.Point(111, 86);
+            this.label21.Location = new System.Drawing.Point(111, 79);
             this.label21.Name = "label21";
-            this.label21.Size = new System.Drawing.Size(31, 13);
+            this.label21.Size = new System.Drawing.Size(31, 12);
             this.label21.TabIndex = 41;
             this.label21.Text = "Pitch";
             // 
             // label33
             // 
             this.label33.AutoSize = true;
-            this.label33.Location = new System.Drawing.Point(372, 143);
+            this.label33.Location = new System.Drawing.Point(372, 132);
             this.label33.Name = "label33";
-            this.label33.Size = new System.Drawing.Size(34, 13);
+            this.label33.Size = new System.Drawing.Size(34, 12);
             this.label33.TabIndex = 56;
             this.label33.Text = "Alpha";
             // 
             // domainUpDownRed
             // 
-            this.domainUpDownRed.Location = new System.Drawing.Point(412, 61);
+            this.domainUpDownRed.Location = new System.Drawing.Point(412, 56);
             this.domainUpDownRed.Name = "domainUpDownRed";
-            this.domainUpDownRed.Size = new System.Drawing.Size(60, 20);
+            this.domainUpDownRed.Size = new System.Drawing.Size(60, 19);
             this.domainUpDownRed.TabIndex = 50;
             this.domainUpDownRed.Text = "1";
             // 
             // label24
             // 
             this.label24.AutoSize = true;
-            this.label24.Location = new System.Drawing.Point(22, 112);
+            this.label24.Location = new System.Drawing.Point(22, 103);
             this.label24.Name = "label24";
-            this.label24.Size = new System.Drawing.Size(12, 13);
+            this.label24.Size = new System.Drawing.Size(10, 12);
             this.label24.TabIndex = 38;
             this.label24.Text = "z";
             // 
             // label22
             // 
             this.label22.AutoSize = true;
-            this.label22.Location = new System.Drawing.Point(117, 60);
+            this.label22.Location = new System.Drawing.Point(117, 55);
             this.label22.Name = "label22";
-            this.label22.Size = new System.Drawing.Size(25, 13);
+            this.label22.Size = new System.Drawing.Size(25, 12);
             this.label22.TabIndex = 40;
             this.label22.Text = "Roll";
             // 
             // label32
             // 
             this.label32.AutoSize = true;
-            this.label32.Location = new System.Drawing.Point(378, 117);
+            this.label32.Location = new System.Drawing.Point(378, 108);
             this.label32.Name = "label32";
-            this.label32.Size = new System.Drawing.Size(28, 13);
+            this.label32.Size = new System.Drawing.Size(28, 12);
             this.label32.TabIndex = 55;
             this.label32.Text = "Blue";
             // 
             // domainUpDownGreen
             // 
-            this.domainUpDownGreen.Location = new System.Drawing.Point(412, 89);
+            this.domainUpDownGreen.Location = new System.Drawing.Point(412, 82);
             this.domainUpDownGreen.Name = "domainUpDownGreen";
-            this.domainUpDownGreen.Size = new System.Drawing.Size(60, 20);
+            this.domainUpDownGreen.Size = new System.Drawing.Size(60, 19);
             this.domainUpDownGreen.TabIndex = 51;
             this.domainUpDownGreen.Text = "1";
             // 
             // textBoxVisualOriginX
             // 
-            this.textBoxVisualOriginX.Location = new System.Drawing.Point(41, 60);
+            this.textBoxVisualOriginX.Location = new System.Drawing.Point(41, 55);
             this.textBoxVisualOriginX.Name = "textBoxVisualOriginX";
-            this.textBoxVisualOriginX.Size = new System.Drawing.Size(66, 20);
+            this.textBoxVisualOriginX.Size = new System.Drawing.Size(66, 19);
             this.textBoxVisualOriginX.TabIndex = 33;
             // 
             // label31
             // 
             this.label31.AutoSize = true;
-            this.label31.Location = new System.Drawing.Point(370, 91);
+            this.label31.Location = new System.Drawing.Point(370, 84);
             this.label31.Name = "label31";
-            this.label31.Size = new System.Drawing.Size(36, 13);
+            this.label31.Size = new System.Drawing.Size(35, 12);
             this.label31.TabIndex = 54;
             this.label31.Text = "Green";
             // 
             // domainUpDownBlue
             // 
-            this.domainUpDownBlue.Location = new System.Drawing.Point(412, 115);
+            this.domainUpDownBlue.Location = new System.Drawing.Point(412, 106);
             this.domainUpDownBlue.Name = "domainUpDownBlue";
-            this.domainUpDownBlue.Size = new System.Drawing.Size(60, 20);
+            this.domainUpDownBlue.Size = new System.Drawing.Size(60, 19);
             this.domainUpDownBlue.TabIndex = 52;
             this.domainUpDownBlue.Text = "1";
             // 
             // label23
             // 
             this.label23.AutoSize = true;
-            this.label23.Location = new System.Drawing.Point(7, 33);
+            this.label23.Location = new System.Drawing.Point(7, 30);
             this.label23.Name = "label23";
-            this.label23.Size = new System.Drawing.Size(51, 13);
+            this.label23.Size = new System.Drawing.Size(56, 12);
             this.label23.TabIndex = 39;
             this.label23.Text = "Origin (m)";
             // 
             // textBoxVisualOriginY
             // 
-            this.textBoxVisualOriginY.Location = new System.Drawing.Point(41, 86);
+            this.textBoxVisualOriginY.Location = new System.Drawing.Point(41, 79);
             this.textBoxVisualOriginY.Name = "textBoxVisualOriginY";
-            this.textBoxVisualOriginY.Size = new System.Drawing.Size(66, 20);
+            this.textBoxVisualOriginY.Size = new System.Drawing.Size(66, 19);
             this.textBoxVisualOriginY.TabIndex = 34;
             // 
             // label30
             // 
             this.label30.AutoSize = true;
-            this.label30.Location = new System.Drawing.Point(379, 63);
+            this.label30.Location = new System.Drawing.Point(379, 58);
             this.label30.Name = "label30";
-            this.label30.Size = new System.Drawing.Size(27, 13);
+            this.label30.Size = new System.Drawing.Size(25, 12);
             this.label30.TabIndex = 53;
             this.label30.Text = "Red";
             // 
             // textBoxTexture
             // 
-            this.textBoxTexture.Location = new System.Drawing.Point(16, 301);
+            this.textBoxTexture.Location = new System.Drawing.Point(16, 278);
             this.textBoxTexture.Name = "textBoxTexture";
-            this.textBoxTexture.Size = new System.Drawing.Size(352, 20);
+            this.textBoxTexture.Size = new System.Drawing.Size(352, 19);
             this.textBoxTexture.TabIndex = 58;
             // 
             // treeViewLinkProperties
@@ -854,18 +893,18 @@
             this.treeViewLinkProperties.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
             | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.treeViewLinkProperties.Location = new System.Drawing.Point(12, 80);
+            this.treeViewLinkProperties.Location = new System.Drawing.Point(12, 74);
             this.treeViewLinkProperties.Name = "treeViewLinkProperties";
-            this.treeViewLinkProperties.Size = new System.Drawing.Size(451, 568);
+            this.treeViewLinkProperties.Size = new System.Drawing.Size(451, 525);
             this.treeViewLinkProperties.TabIndex = 74;
             this.treeViewLinkProperties.AfterSelect += new System.Windows.Forms.TreeViewEventHandler(this.TreeViewLinkPropertiesAfterSelect);
             // 
             // buttonJointNext
             // 
             this.buttonJointNext.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-            this.buttonJointNext.Location = new System.Drawing.Point(986, 653);
+            this.buttonJointNext.Location = new System.Drawing.Point(986, 603);
             this.buttonJointNext.Name = "buttonJointNext";
-            this.buttonJointNext.Size = new System.Drawing.Size(75, 23);
+            this.buttonJointNext.Size = new System.Drawing.Size(75, 21);
             this.buttonJointNext.TabIndex = 162;
             this.buttonJointNext.Text = "Next";
             this.buttonJointNext.UseVisualStyleBackColor = true;
@@ -874,9 +913,9 @@
             // buttonJointCancel
             // 
             this.buttonJointCancel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-            this.buttonJointCancel.Location = new System.Drawing.Point(12, 653);
+            this.buttonJointCancel.Location = new System.Drawing.Point(12, 603);
             this.buttonJointCancel.Name = "buttonJointCancel";
-            this.buttonJointCancel.Size = new System.Drawing.Size(75, 23);
+            this.buttonJointCancel.Size = new System.Drawing.Size(75, 21);
             this.buttonJointCancel.TabIndex = 160;
             this.buttonJointCancel.Text = "Cancel";
             this.buttonJointCancel.UseVisualStyleBackColor = true;
@@ -886,7 +925,7 @@
             // 
             this.label7.AutoSize = true;
             this.label7.Font = new System.Drawing.Font("Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.label7.Location = new System.Drawing.Point(12, 9);
+            this.label7.Location = new System.Drawing.Point(12, 8);
             this.label7.Name = "label7";
             this.label7.Size = new System.Drawing.Size(198, 17);
             this.label7.TabIndex = 223;
@@ -895,66 +934,66 @@
             // label6
             // 
             this.label6.AutoSize = true;
-            this.label6.Location = new System.Drawing.Point(633, 286);
+            this.label6.Location = new System.Drawing.Point(633, 264);
             this.label6.Name = "label6";
-            this.label6.Size = new System.Drawing.Size(82, 13);
+            this.label6.Size = new System.Drawing.Size(89, 12);
             this.label6.TabIndex = 221;
             this.label6.Text = "Orientation (rad)";
             // 
             // label3
             // 
             this.label3.AutoSize = true;
-            this.label3.Location = new System.Drawing.Point(528, 286);
+            this.label3.Location = new System.Drawing.Point(528, 264);
             this.label3.Name = "label3";
-            this.label3.Size = new System.Drawing.Size(61, 13);
+            this.label3.Size = new System.Drawing.Size(67, 12);
             this.label3.TabIndex = 220;
             this.label3.Text = "Position (m)";
             // 
             // textBoxKVelocity
             // 
-            this.textBoxKVelocity.Location = new System.Drawing.Point(955, 540);
+            this.textBoxKVelocity.Location = new System.Drawing.Point(955, 498);
             this.textBoxKVelocity.Name = "textBoxKVelocity";
-            this.textBoxKVelocity.Size = new System.Drawing.Size(66, 20);
+            this.textBoxKVelocity.Size = new System.Drawing.Size(66, 19);
             this.textBoxKVelocity.TabIndex = 218;
             // 
             // labelKVelocity
             // 
             this.labelKVelocity.AutoSize = true;
-            this.labelKVelocity.Location = new System.Drawing.Point(897, 543);
+            this.labelKVelocity.Location = new System.Drawing.Point(897, 501);
             this.labelKVelocity.Name = "labelKVelocity";
-            this.labelKVelocity.Size = new System.Drawing.Size(52, 13);
+            this.labelKVelocity.Size = new System.Drawing.Size(55, 12);
             this.labelKVelocity.TabIndex = 219;
             this.labelKVelocity.Text = "k velocity";
             // 
             // textBoxSoftLower
             // 
-            this.textBoxSoftLower.Location = new System.Drawing.Point(955, 460);
+            this.textBoxSoftLower.Location = new System.Drawing.Point(955, 425);
             this.textBoxSoftLower.Name = "textBoxSoftLower";
-            this.textBoxSoftLower.Size = new System.Drawing.Size(66, 20);
+            this.textBoxSoftLower.Size = new System.Drawing.Size(66, 19);
             this.textBoxSoftLower.TabIndex = 211;
             // 
             // labelSoftLower
             // 
             this.labelSoftLower.AutoSize = true;
-            this.labelSoftLower.Location = new System.Drawing.Point(854, 463);
+            this.labelSoftLower.Location = new System.Drawing.Point(854, 427);
             this.labelSoftLower.Name = "labelSoftLower";
-            this.labelSoftLower.Size = new System.Drawing.Size(96, 13);
+            this.labelSoftLower.Size = new System.Drawing.Size(110, 12);
             this.labelSoftLower.TabIndex = 214;
             this.labelSoftLower.Text = "soft lower limit (rad)";
             // 
             // textBoxSoftUpper
             // 
-            this.textBoxSoftUpper.Location = new System.Drawing.Point(955, 488);
+            this.textBoxSoftUpper.Location = new System.Drawing.Point(955, 450);
             this.textBoxSoftUpper.Name = "textBoxSoftUpper";
-            this.textBoxSoftUpper.Size = new System.Drawing.Size(66, 20);
+            this.textBoxSoftUpper.Size = new System.Drawing.Size(66, 19);
             this.textBoxSoftUpper.TabIndex = 212;
             // 
             // labelSoftUpper
             // 
             this.labelSoftUpper.AutoSize = true;
-            this.labelSoftUpper.Location = new System.Drawing.Point(850, 491);
+            this.labelSoftUpper.Location = new System.Drawing.Point(850, 453);
             this.labelSoftUpper.Name = "labelSoftUpper";
-            this.labelSoftUpper.Size = new System.Drawing.Size(98, 13);
+            this.labelSoftUpper.Size = new System.Drawing.Size(111, 12);
             this.labelSoftUpper.TabIndex = 215;
             this.labelSoftUpper.Text = "soft upper limit (rad)";
             // 
@@ -962,7 +1001,7 @@
             // 
             this.label80.AutoSize = true;
             this.label80.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.label80.Location = new System.Drawing.Point(952, 431);
+            this.label80.Location = new System.Drawing.Point(952, 398);
             this.label80.Name = "label80";
             this.label80.Size = new System.Drawing.Size(101, 13);
             this.label80.TabIndex = 217;
@@ -970,49 +1009,49 @@
             // 
             // textBoxKPosition
             // 
-            this.textBoxKPosition.Location = new System.Drawing.Point(955, 514);
+            this.textBoxKPosition.Location = new System.Drawing.Point(955, 474);
             this.textBoxKPosition.Name = "textBoxKPosition";
-            this.textBoxKPosition.Size = new System.Drawing.Size(66, 20);
+            this.textBoxKPosition.Size = new System.Drawing.Size(66, 19);
             this.textBoxKPosition.TabIndex = 213;
             // 
             // labelKPosition
             // 
             this.labelKPosition.AutoSize = true;
-            this.labelKPosition.Location = new System.Drawing.Point(897, 517);
+            this.labelKPosition.Location = new System.Drawing.Point(897, 477);
             this.labelKPosition.Name = "labelKPosition";
-            this.labelKPosition.Size = new System.Drawing.Size(52, 13);
+            this.labelKPosition.Size = new System.Drawing.Size(55, 12);
             this.labelKPosition.TabIndex = 216;
             this.labelKPosition.Text = "k position";
             // 
             // textBoxFriction
             // 
-            this.textBoxFriction.Location = new System.Drawing.Point(766, 460);
+            this.textBoxFriction.Location = new System.Drawing.Point(766, 425);
             this.textBoxFriction.Name = "textBoxFriction";
-            this.textBoxFriction.Size = new System.Drawing.Size(66, 20);
+            this.textBoxFriction.Size = new System.Drawing.Size(66, 19);
             this.textBoxFriction.TabIndex = 206;
             // 
             // labelFriction
             // 
             this.labelFriction.AutoSize = true;
-            this.labelFriction.Location = new System.Drawing.Point(694, 463);
+            this.labelFriction.Location = new System.Drawing.Point(694, 427);
             this.labelFriction.Name = "labelFriction";
-            this.labelFriction.Size = new System.Drawing.Size(67, 13);
+            this.labelFriction.Size = new System.Drawing.Size(76, 12);
             this.labelFriction.TabIndex = 208;
             this.labelFriction.Text = "friction (N*m)";
             // 
             // textBoxDamping
             // 
-            this.textBoxDamping.Location = new System.Drawing.Point(766, 486);
+            this.textBoxDamping.Location = new System.Drawing.Point(766, 449);
             this.textBoxDamping.Name = "textBoxDamping";
-            this.textBoxDamping.Size = new System.Drawing.Size(66, 20);
+            this.textBoxDamping.Size = new System.Drawing.Size(66, 19);
             this.textBoxDamping.TabIndex = 207;
             // 
             // labelDamping
             // 
             this.labelDamping.AutoSize = true;
-            this.labelDamping.Location = new System.Drawing.Point(642, 489);
+            this.labelDamping.Location = new System.Drawing.Point(642, 451);
             this.labelDamping.Name = "labelDamping";
-            this.labelDamping.Size = new System.Drawing.Size(119, 13);
+            this.labelDamping.Size = new System.Drawing.Size(133, 12);
             this.labelDamping.TabIndex = 209;
             this.labelDamping.Text = "damping (N*m*s*rad^-1)";
             // 
@@ -1020,7 +1059,7 @@
             // 
             this.label76.AutoSize = true;
             this.label76.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.label76.Location = new System.Drawing.Point(764, 427);
+            this.label76.Location = new System.Drawing.Point(764, 394);
             this.label76.Name = "label76";
             this.label76.Size = new System.Drawing.Size(61, 13);
             this.label76.TabIndex = 210;
@@ -1028,33 +1067,33 @@
             // 
             // textBoxCalibrationRising
             // 
-            this.textBoxCalibrationRising.Location = new System.Drawing.Point(531, 460);
+            this.textBoxCalibrationRising.Location = new System.Drawing.Point(531, 425);
             this.textBoxCalibrationRising.Name = "textBoxCalibrationRising";
-            this.textBoxCalibrationRising.Size = new System.Drawing.Size(66, 20);
+            this.textBoxCalibrationRising.Size = new System.Drawing.Size(66, 19);
             this.textBoxCalibrationRising.TabIndex = 201;
             // 
             // label7CalibrationRising
             // 
             this.label7CalibrationRising.AutoSize = true;
-            this.label7CalibrationRising.Location = new System.Drawing.Point(494, 463);
+            this.label7CalibrationRising.Location = new System.Drawing.Point(494, 427);
             this.label7CalibrationRising.Name = "label7CalibrationRising";
-            this.label7CalibrationRising.Size = new System.Drawing.Size(31, 13);
+            this.label7CalibrationRising.Size = new System.Drawing.Size(33, 12);
             this.label7CalibrationRising.TabIndex = 203;
             this.label7CalibrationRising.Text = "rising";
             // 
             // textBoxCalibrationFalling
             // 
-            this.textBoxCalibrationFalling.Location = new System.Drawing.Point(531, 486);
+            this.textBoxCalibrationFalling.Location = new System.Drawing.Point(531, 449);
             this.textBoxCalibrationFalling.Name = "textBoxCalibrationFalling";
-            this.textBoxCalibrationFalling.Size = new System.Drawing.Size(66, 20);
+            this.textBoxCalibrationFalling.Size = new System.Drawing.Size(66, 19);
             this.textBoxCalibrationFalling.TabIndex = 202;
             // 
             // label73
             // 
             this.label73.AutoSize = true;
-            this.label73.Location = new System.Drawing.Point(490, 489);
+            this.label73.Location = new System.Drawing.Point(490, 451);
             this.label73.Name = "label73";
-            this.label73.Size = new System.Drawing.Size(34, 13);
+            this.label73.Size = new System.Drawing.Size(36, 12);
             this.label73.TabIndex = 204;
             this.label73.Text = "falling";
             // 
@@ -1062,7 +1101,7 @@
             // 
             this.label74.AutoSize = true;
             this.label74.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.label74.Location = new System.Drawing.Point(528, 427);
+            this.label74.Location = new System.Drawing.Point(528, 394);
             this.label74.Name = "label74";
             this.label74.Size = new System.Drawing.Size(67, 13);
             this.label74.TabIndex = 205;
@@ -1070,49 +1109,49 @@
             // 
             // textBoxLimitVelocity
             // 
-            this.textBoxLimitVelocity.Location = new System.Drawing.Point(955, 379);
+            this.textBoxLimitVelocity.Location = new System.Drawing.Point(955, 350);
             this.textBoxLimitVelocity.Name = "textBoxLimitVelocity";
-            this.textBoxLimitVelocity.Size = new System.Drawing.Size(66, 20);
+            this.textBoxLimitVelocity.Size = new System.Drawing.Size(66, 19);
             this.textBoxLimitVelocity.TabIndex = 199;
             // 
             // labelVelocity
             // 
             this.labelVelocity.AutoSize = true;
-            this.labelVelocity.Location = new System.Drawing.Point(879, 381);
+            this.labelVelocity.Location = new System.Drawing.Point(879, 352);
             this.labelVelocity.Name = "labelVelocity";
-            this.labelVelocity.Size = new System.Drawing.Size(70, 13);
+            this.labelVelocity.Size = new System.Drawing.Size(78, 12);
             this.labelVelocity.TabIndex = 200;
             this.labelVelocity.Text = "velocity (m/s)";
             // 
             // textBoxLimitLower
             // 
-            this.textBoxLimitLower.Location = new System.Drawing.Point(955, 301);
+            this.textBoxLimitLower.Location = new System.Drawing.Point(955, 278);
             this.textBoxLimitLower.Name = "textBoxLimitLower";
-            this.textBoxLimitLower.Size = new System.Drawing.Size(66, 20);
+            this.textBoxLimitLower.Size = new System.Drawing.Size(66, 19);
             this.textBoxLimitLower.TabIndex = 192;
             // 
             // labelLowerLimit
             // 
             this.labelLowerLimit.AutoSize = true;
-            this.labelLowerLimit.Location = new System.Drawing.Point(893, 303);
+            this.labelLowerLimit.Location = new System.Drawing.Point(893, 280);
             this.labelLowerLimit.Name = "labelLowerLimit";
-            this.labelLowerLimit.Size = new System.Drawing.Size(56, 13);
+            this.labelLowerLimit.Size = new System.Drawing.Size(60, 12);
             this.labelLowerLimit.TabIndex = 195;
             this.labelLowerLimit.Text = "lower (rad)";
             // 
             // textBoxLimitUpper
             // 
-            this.textBoxLimitUpper.Location = new System.Drawing.Point(955, 327);
+            this.textBoxLimitUpper.Location = new System.Drawing.Point(955, 302);
             this.textBoxLimitUpper.Name = "textBoxLimitUpper";
-            this.textBoxLimitUpper.Size = new System.Drawing.Size(66, 20);
+            this.textBoxLimitUpper.Size = new System.Drawing.Size(66, 19);
             this.textBoxLimitUpper.TabIndex = 193;
             // 
             // labelLimitUpper
             // 
             this.labelLimitUpper.AutoSize = true;
-            this.labelLimitUpper.Location = new System.Drawing.Point(891, 330);
+            this.labelLimitUpper.Location = new System.Drawing.Point(891, 305);
             this.labelLimitUpper.Name = "labelLimitUpper";
-            this.labelLimitUpper.Size = new System.Drawing.Size(58, 13);
+            this.labelLimitUpper.Size = new System.Drawing.Size(61, 12);
             this.labelLimitUpper.TabIndex = 196;
             this.labelLimitUpper.Text = "upper (rad)";
             // 
@@ -1120,7 +1159,7 @@
             // 
             this.label68.AutoSize = true;
             this.label68.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.label68.Location = new System.Drawing.Point(952, 269);
+            this.label68.Location = new System.Drawing.Point(952, 248);
             this.label68.Name = "label68";
             this.label68.Size = new System.Drawing.Size(33, 13);
             this.label68.TabIndex = 198;
@@ -1128,17 +1167,17 @@
             // 
             // textBoxLimitEffort
             // 
-            this.textBoxLimitEffort.Location = new System.Drawing.Point(955, 353);
+            this.textBoxLimitEffort.Location = new System.Drawing.Point(955, 326);
             this.textBoxLimitEffort.Name = "textBoxLimitEffort";
-            this.textBoxLimitEffort.Size = new System.Drawing.Size(66, 20);
+            this.textBoxLimitEffort.Size = new System.Drawing.Size(66, 19);
             this.textBoxLimitEffort.TabIndex = 194;
             // 
             // labelEffort
             // 
             this.labelEffort.AutoSize = true;
-            this.labelEffort.Location = new System.Drawing.Point(890, 355);
+            this.labelEffort.Location = new System.Drawing.Point(890, 328);
             this.labelEffort.Name = "labelEffort";
-            this.labelEffort.Size = new System.Drawing.Size(59, 13);
+            this.labelEffort.Size = new System.Drawing.Size(68, 12);
             this.labelEffort.TabIndex = 197;
             this.labelEffort.Text = "effort (N-m)";
             // 
@@ -1146,7 +1185,7 @@
             // 
             this.label65.AutoSize = true;
             this.label65.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.label65.Location = new System.Drawing.Point(519, 106);
+            this.label65.Location = new System.Drawing.Point(519, 98);
             this.label65.Name = "label65";
             this.label65.Size = new System.Drawing.Size(56, 13);
             this.label65.TabIndex = 191;
@@ -1156,7 +1195,7 @@
             // 
             this.label64.AutoSize = true;
             this.label64.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.label64.Location = new System.Drawing.Point(512, 80);
+            this.label64.Location = new System.Drawing.Point(512, 74);
             this.label64.Name = "label64";
             this.label64.Size = new System.Drawing.Size(64, 13);
             this.label64.TabIndex = 190;
@@ -1166,7 +1205,7 @@
             // 
             this.label63.AutoSize = true;
             this.label63.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.label63.Location = new System.Drawing.Point(513, 130);
+            this.label63.Location = new System.Drawing.Point(513, 120);
             this.label63.Name = "label63";
             this.label63.Size = new System.Drawing.Size(60, 13);
             this.label63.TabIndex = 189;
@@ -1174,16 +1213,16 @@
             // 
             // textBoxJointName
             // 
-            this.textBoxJointName.Location = new System.Drawing.Point(537, 148);
+            this.textBoxJointName.Location = new System.Drawing.Point(537, 137);
             this.textBoxJointName.Name = "textBoxJointName";
-            this.textBoxJointName.Size = new System.Drawing.Size(295, 20);
+            this.textBoxJointName.Size = new System.Drawing.Size(295, 19);
             this.textBoxJointName.TabIndex = 188;
             // 
             // label62
             // 
             this.label62.AutoSize = true;
             this.label62.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.label62.Location = new System.Drawing.Point(854, 132);
+            this.label62.Location = new System.Drawing.Point(854, 122);
             this.label62.Name = "label62";
             this.label62.Size = new System.Drawing.Size(56, 13);
             this.label62.TabIndex = 187;
@@ -1199,40 +1238,40 @@
             "planar",
             "prismatic",
             "revolute"});
-            this.comboBoxJointType.Location = new System.Drawing.Point(890, 149);
+            this.comboBoxJointType.Location = new System.Drawing.Point(890, 138);
             this.comboBoxJointType.Name = "comboBoxJointType";
-            this.comboBoxJointType.Size = new System.Drawing.Size(121, 21);
+            this.comboBoxJointType.Size = new System.Drawing.Size(121, 20);
             this.comboBoxJointType.TabIndex = 186;
             // 
             // textBoxAxisX
             // 
-            this.textBoxAxisX.Location = new System.Drawing.Point(766, 303);
+            this.textBoxAxisX.Location = new System.Drawing.Point(766, 280);
             this.textBoxAxisX.Name = "textBoxAxisX";
-            this.textBoxAxisX.Size = new System.Drawing.Size(66, 20);
+            this.textBoxAxisX.Size = new System.Drawing.Size(66, 19);
             this.textBoxAxisX.TabIndex = 179;
             // 
             // label58
             // 
             this.label58.AutoSize = true;
-            this.label58.Location = new System.Drawing.Point(749, 303);
+            this.label58.Location = new System.Drawing.Point(749, 280);
             this.label58.Name = "label58";
-            this.label58.Size = new System.Drawing.Size(12, 13);
+            this.label58.Size = new System.Drawing.Size(11, 12);
             this.label58.TabIndex = 182;
             this.label58.Text = "x";
             // 
             // textBoxAxisY
             // 
-            this.textBoxAxisY.Location = new System.Drawing.Point(766, 329);
+            this.textBoxAxisY.Location = new System.Drawing.Point(766, 304);
             this.textBoxAxisY.Name = "textBoxAxisY";
-            this.textBoxAxisY.Size = new System.Drawing.Size(66, 20);
+            this.textBoxAxisY.Size = new System.Drawing.Size(66, 19);
             this.textBoxAxisY.TabIndex = 180;
             // 
             // label59
             // 
             this.label59.AutoSize = true;
-            this.label59.Location = new System.Drawing.Point(749, 332);
+            this.label59.Location = new System.Drawing.Point(749, 306);
             this.label59.Name = "label59";
-            this.label59.Size = new System.Drawing.Size(12, 13);
+            this.label59.Size = new System.Drawing.Size(11, 12);
             this.label59.TabIndex = 183;
             this.label59.Text = "y";
             // 
@@ -1240,7 +1279,7 @@
             // 
             this.label60.AutoSize = true;
             this.label60.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.label60.Location = new System.Drawing.Point(764, 269);
+            this.label60.Location = new System.Drawing.Point(764, 248);
             this.label60.Name = "label60";
             this.label60.Size = new System.Drawing.Size(30, 13);
             this.label60.TabIndex = 185;
@@ -1248,79 +1287,79 @@
             // 
             // textBoxAxisZ
             // 
-            this.textBoxAxisZ.Location = new System.Drawing.Point(766, 355);
+            this.textBoxAxisZ.Location = new System.Drawing.Point(766, 328);
             this.textBoxAxisZ.Name = "textBoxAxisZ";
-            this.textBoxAxisZ.Size = new System.Drawing.Size(66, 20);
+            this.textBoxAxisZ.Size = new System.Drawing.Size(66, 19);
             this.textBoxAxisZ.TabIndex = 181;
             // 
             // label61
             // 
             this.label61.AutoSize = true;
-            this.label61.Location = new System.Drawing.Point(749, 357);
+            this.label61.Location = new System.Drawing.Point(749, 330);
             this.label61.Name = "label61";
-            this.label61.Size = new System.Drawing.Size(12, 13);
+            this.label61.Size = new System.Drawing.Size(10, 12);
             this.label61.TabIndex = 184;
             this.label61.Text = "z";
             // 
             // textBoxJointX
             // 
-            this.textBoxJointX.Location = new System.Drawing.Point(530, 303);
+            this.textBoxJointX.Location = new System.Drawing.Point(530, 280);
             this.textBoxJointX.Name = "textBoxJointX";
-            this.textBoxJointX.Size = new System.Drawing.Size(66, 20);
+            this.textBoxJointX.Size = new System.Drawing.Size(66, 19);
             this.textBoxJointX.TabIndex = 166;
             // 
             // label51
             // 
             this.label51.AutoSize = true;
-            this.label51.Location = new System.Drawing.Point(606, 307);
+            this.label51.Location = new System.Drawing.Point(606, 283);
             this.label51.Name = "label51";
-            this.label51.Size = new System.Drawing.Size(25, 13);
+            this.label51.Size = new System.Drawing.Size(25, 12);
             this.label51.TabIndex = 173;
             this.label51.Text = "Roll";
             // 
             // textBoxJointYaw
             // 
-            this.textBoxJointYaw.Location = new System.Drawing.Point(638, 355);
+            this.textBoxJointYaw.Location = new System.Drawing.Point(638, 328);
             this.textBoxJointYaw.Name = "textBoxJointYaw";
-            this.textBoxJointYaw.Size = new System.Drawing.Size(66, 20);
+            this.textBoxJointYaw.Size = new System.Drawing.Size(66, 19);
             this.textBoxJointYaw.TabIndex = 178;
             // 
             // textBoxJointPitch
             // 
-            this.textBoxJointPitch.Location = new System.Drawing.Point(638, 329);
+            this.textBoxJointPitch.Location = new System.Drawing.Point(638, 304);
             this.textBoxJointPitch.Name = "textBoxJointPitch";
-            this.textBoxJointPitch.Size = new System.Drawing.Size(66, 20);
+            this.textBoxJointPitch.Size = new System.Drawing.Size(66, 19);
             this.textBoxJointPitch.TabIndex = 177;
             // 
             // label52
             // 
             this.label52.AutoSize = true;
-            this.label52.Location = new System.Drawing.Point(512, 303);
+            this.label52.Location = new System.Drawing.Point(512, 280);
             this.label52.Name = "label52";
-            this.label52.Size = new System.Drawing.Size(12, 13);
+            this.label52.Size = new System.Drawing.Size(11, 12);
             this.label52.TabIndex = 169;
             this.label52.Text = "x";
             // 
             // textBoxJointRoll
             // 
-            this.textBoxJointRoll.Location = new System.Drawing.Point(638, 303);
+            this.textBoxJointRoll.Location = new System.Drawing.Point(638, 280);
             this.textBoxJointRoll.Name = "textBoxJointRoll";
-            this.textBoxJointRoll.Size = new System.Drawing.Size(66, 20);
+            this.textBoxJointRoll.Size = new System.Drawing.Size(66, 19);
             this.textBoxJointRoll.TabIndex = 176;
             // 
             // textBoxJointY
             // 
-            this.textBoxJointY.Location = new System.Drawing.Point(530, 329);
+            this.textBoxJointY.Location = new System.Drawing.Point(530, 304);
             this.textBoxJointY.Name = "textBoxJointY";
-            this.textBoxJointY.Size = new System.Drawing.Size(66, 20);
+            this.textBoxJointY.Size = new System.Drawing.Size(66, 19);
             this.textBoxJointY.TabIndex = 167;
             // 
             // label53
             // 
             this.label53.AutoSize = true;
-            this.label53.Location = new System.Drawing.Point(512, 332);
+            this.label53.Location = new System.Drawing.Point(512, 306);
             this.label53.Name = "label53";
-            this.label53.Size = new System.Drawing.Size(12, 13);
+            this.label53.Size = new System.Drawing.Size(11, 12);
             this.label53.TabIndex = 170;
             this.label53.Text = "y";
             // 
@@ -1328,7 +1367,7 @@
             // 
             this.label54.AutoSize = true;
             this.label54.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.label54.Location = new System.Drawing.Point(528, 269);
+            this.label54.Location = new System.Drawing.Point(528, 248);
             this.label54.Name = "label54";
             this.label54.Size = new System.Drawing.Size(40, 13);
             this.label54.TabIndex = 172;
@@ -1337,58 +1376,58 @@
             // label55
             // 
             this.label55.AutoSize = true;
-            this.label55.Location = new System.Drawing.Point(602, 333);
+            this.label55.Location = new System.Drawing.Point(602, 307);
             this.label55.Name = "label55";
-            this.label55.Size = new System.Drawing.Size(31, 13);
+            this.label55.Size = new System.Drawing.Size(31, 12);
             this.label55.TabIndex = 174;
             this.label55.Text = "Pitch";
             // 
             // label56
             // 
             this.label56.AutoSize = true;
-            this.label56.Location = new System.Drawing.Point(604, 358);
+            this.label56.Location = new System.Drawing.Point(604, 330);
             this.label56.Name = "label56";
-            this.label56.Size = new System.Drawing.Size(28, 13);
+            this.label56.Size = new System.Drawing.Size(26, 12);
             this.label56.TabIndex = 175;
             this.label56.Text = "Yaw";
             // 
             // textBoxJointZ
             // 
-            this.textBoxJointZ.Location = new System.Drawing.Point(530, 355);
+            this.textBoxJointZ.Location = new System.Drawing.Point(530, 328);
             this.textBoxJointZ.Name = "textBoxJointZ";
-            this.textBoxJointZ.Size = new System.Drawing.Size(66, 20);
+            this.textBoxJointZ.Size = new System.Drawing.Size(66, 19);
             this.textBoxJointZ.TabIndex = 168;
             // 
             // label57
             // 
             this.label57.AutoSize = true;
-            this.label57.Location = new System.Drawing.Point(513, 358);
+            this.label57.Location = new System.Drawing.Point(513, 330);
             this.label57.Name = "label57";
-            this.label57.Size = new System.Drawing.Size(12, 13);
+            this.label57.Size = new System.Drawing.Size(10, 12);
             this.label57.TabIndex = 171;
             this.label57.Text = "z";
             // 
             // labelChild
             // 
             this.labelChild.AutoSize = true;
-            this.labelChild.Location = new System.Drawing.Point(574, 106);
+            this.labelChild.Location = new System.Drawing.Point(574, 98);
             this.labelChild.Name = "labelChild";
-            this.labelChild.Size = new System.Drawing.Size(0, 13);
+            this.labelChild.Size = new System.Drawing.Size(0, 12);
             this.labelChild.TabIndex = 165;
             // 
             // labelParent
             // 
             this.labelParent.AutoSize = true;
-            this.labelParent.Location = new System.Drawing.Point(574, 80);
+            this.labelParent.Location = new System.Drawing.Point(574, 74);
             this.labelParent.Name = "labelParent";
-            this.labelParent.Size = new System.Drawing.Size(0, 13);
+            this.labelParent.Size = new System.Drawing.Size(0, 12);
             this.labelParent.TabIndex = 164;
             // 
             // treeViewJointTree
             // 
-            this.treeViewJointTree.Location = new System.Drawing.Point(12, 80);
+            this.treeViewJointTree.Location = new System.Drawing.Point(12, 74);
             this.treeViewJointTree.Name = "treeViewJointTree";
-            this.treeViewJointTree.Size = new System.Drawing.Size(462, 568);
+            this.treeViewJointTree.Size = new System.Drawing.Size(462, 525);
             this.treeViewJointTree.TabIndex = 163;
             this.treeViewJointTree.AfterSelect += new System.Windows.Forms.TreeViewEventHandler(this.TreeViewJointtreeAfterSelect);
             // 
@@ -1396,9 +1435,9 @@
             // 
             this.comboBoxAxis.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.comboBoxAxis.FormattingEnabled = true;
-            this.comboBoxAxis.Location = new System.Drawing.Point(570, 226);
+            this.comboBoxAxis.Location = new System.Drawing.Point(570, 209);
             this.comboBoxAxis.Name = "comboBoxAxis";
-            this.comboBoxAxis.Size = new System.Drawing.Size(468, 21);
+            this.comboBoxAxis.Size = new System.Drawing.Size(468, 20);
             this.comboBoxAxis.TabIndex = 224;
             this.comboBoxAxis.SelectedIndexChanged += new System.EventHandler(this.ComboBoxAxisSelectedIndexChanged);
             // 
@@ -1406,34 +1445,34 @@
             // 
             this.comboBoxOrigin.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.comboBoxOrigin.FormattingEnabled = true;
-            this.comboBoxOrigin.Location = new System.Drawing.Point(570, 191);
+            this.comboBoxOrigin.Location = new System.Drawing.Point(570, 176);
             this.comboBoxOrigin.Name = "comboBoxOrigin";
-            this.comboBoxOrigin.Size = new System.Drawing.Size(468, 21);
+            this.comboBoxOrigin.Size = new System.Drawing.Size(468, 20);
             this.comboBoxOrigin.TabIndex = 225;
             // 
             // label66
             // 
             this.label66.AutoSize = true;
-            this.label66.Location = new System.Drawing.Point(501, 193);
+            this.label66.Location = new System.Drawing.Point(501, 178);
             this.label66.Name = "label66";
-            this.label66.Size = new System.Drawing.Size(63, 13);
+            this.label66.Size = new System.Drawing.Size(66, 12);
             this.label66.TabIndex = 226;
             this.label66.Text = "Coordinates";
             // 
             // label67
             // 
             this.label67.AutoSize = true;
-            this.label67.Location = new System.Drawing.Point(538, 229);
+            this.label67.Location = new System.Drawing.Point(538, 211);
             this.label67.Name = "label67";
-            this.label67.Size = new System.Drawing.Size(26, 13);
+            this.label67.Size = new System.Drawing.Size(28, 12);
             this.label67.TabIndex = 227;
             this.label67.Text = "Axis";
             // 
             // label69
             // 
-            this.label69.Location = new System.Drawing.Point(22, 34);
+            this.label69.Location = new System.Drawing.Point(22, 31);
             this.label69.Name = "label69";
-            this.label69.Size = new System.Drawing.Size(451, 54);
+            this.label69.Size = new System.Drawing.Size(451, 50);
             this.label69.TabIndex = 228;
             this.label69.Text = "Customize the joint properties. If you want to adjust the coordinate systems and " +
     "axes in the model, click cancel and restart the export. The tool will recognize " +
@@ -1442,9 +1481,9 @@
             // label4
             // 
             this.label4.AutoSize = true;
-            this.label4.Location = new System.Drawing.Point(521, 653);
+            this.label4.Location = new System.Drawing.Point(521, 603);
             this.label4.Name = "label4";
-            this.label4.Size = new System.Drawing.Size(239, 13);
+            this.label4.Size = new System.Drawing.Size(263, 12);
             this.label4.TabIndex = 230;
             this.label4.Text = "Entries that are blank will not be written to URDF.";
             // 
@@ -1452,7 +1491,7 @@
             // 
             this.label1.AutoSize = true;
             this.label1.Font = new System.Drawing.Font("Microsoft Sans Serif", 7.8F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.label1.Location = new System.Drawing.Point(562, 269);
+            this.label1.Location = new System.Drawing.Point(562, 248);
             this.label1.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.label1.Name = "label1";
             this.label1.Size = new System.Drawing.Size(12, 13);
@@ -1463,7 +1502,7 @@
             // 
             this.AxisRequiredLabel.AutoSize = true;
             this.AxisRequiredLabel.Font = new System.Drawing.Font("Microsoft Sans Serif", 7.8F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.AxisRequiredLabel.Location = new System.Drawing.Point(788, 269);
+            this.AxisRequiredLabel.Location = new System.Drawing.Point(788, 248);
             this.AxisRequiredLabel.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.AxisRequiredLabel.Name = "AxisRequiredLabel";
             this.AxisRequiredLabel.Size = new System.Drawing.Size(12, 13);
@@ -1474,7 +1513,7 @@
             // 
             this.LimitRequiredLabel.AutoSize = true;
             this.LimitRequiredLabel.Font = new System.Drawing.Font("Microsoft Sans Serif", 7.8F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.LimitRequiredLabel.Location = new System.Drawing.Point(980, 268);
+            this.LimitRequiredLabel.Location = new System.Drawing.Point(980, 247);
             this.LimitRequiredLabel.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.LimitRequiredLabel.Name = "LimitRequiredLabel";
             this.LimitRequiredLabel.Size = new System.Drawing.Size(12, 13);
@@ -1485,20 +1524,20 @@
             // label27
             // 
             this.label27.AutoSize = true;
-            this.label27.Location = new System.Drawing.Point(521, 668);
+            this.label27.Location = new System.Drawing.Point(521, 617);
             this.label27.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.label27.Name = "label27";
-            this.label27.Size = new System.Drawing.Size(117, 13);
+            this.label27.Size = new System.Drawing.Size(130, 12);
             this.label27.TabIndex = 234;
             this.label27.Text = "* Field group is required";
             // 
             // MimicCheckBox
             // 
             this.MimicCheckBox.AutoSize = true;
-            this.MimicCheckBox.Location = new System.Drawing.Point(530, 580);
+            this.MimicCheckBox.Location = new System.Drawing.Point(530, 535);
             this.MimicCheckBox.Margin = new System.Windows.Forms.Padding(2);
             this.MimicCheckBox.Name = "MimicCheckBox";
-            this.MimicCheckBox.Size = new System.Drawing.Size(107, 17);
+            this.MimicCheckBox.Size = new System.Drawing.Size(116, 16);
             this.MimicCheckBox.TabIndex = 235;
             this.MimicCheckBox.Text = "Mimic Other Joint";
             this.MimicCheckBox.UseVisualStyleBackColor = true;
@@ -1507,10 +1546,10 @@
             // MimicJointComboBox
             // 
             this.MimicJointComboBox.FormattingEnabled = true;
-            this.MimicJointComboBox.Location = new System.Drawing.Point(532, 620);
+            this.MimicJointComboBox.Location = new System.Drawing.Point(532, 572);
             this.MimicJointComboBox.Margin = new System.Windows.Forms.Padding(2);
             this.MimicJointComboBox.Name = "MimicJointComboBox";
-            this.MimicJointComboBox.Size = new System.Drawing.Size(158, 21);
+            this.MimicJointComboBox.Size = new System.Drawing.Size(158, 20);
             this.MimicJointComboBox.TabIndex = 236;
             this.MimicJointComboBox.Visible = false;
             // 
@@ -1518,7 +1557,7 @@
             // 
             this.MimicJointLabel.AutoSize = true;
             this.MimicJointLabel.Font = new System.Drawing.Font("Microsoft Sans Serif", 7.8F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.MimicJointLabel.Location = new System.Drawing.Point(530, 604);
+            this.MimicJointLabel.Location = new System.Drawing.Point(530, 558);
             this.MimicJointLabel.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.MimicJointLabel.Name = "MimicJointLabel";
             this.MimicJointLabel.Size = new System.Drawing.Size(89, 13);
@@ -1528,28 +1567,28 @@
             // 
             // textBoxMimicMultiplier
             // 
-            this.textBoxMimicMultiplier.Location = new System.Drawing.Point(766, 600);
+            this.textBoxMimicMultiplier.Location = new System.Drawing.Point(766, 554);
             this.textBoxMimicMultiplier.Margin = new System.Windows.Forms.Padding(2);
             this.textBoxMimicMultiplier.Name = "textBoxMimicMultiplier";
-            this.textBoxMimicMultiplier.Size = new System.Drawing.Size(66, 20);
+            this.textBoxMimicMultiplier.Size = new System.Drawing.Size(66, 19);
             this.textBoxMimicMultiplier.TabIndex = 238;
             this.textBoxMimicMultiplier.Visible = false;
             // 
             // textBoxMimicOffset
             // 
-            this.textBoxMimicOffset.Location = new System.Drawing.Point(766, 622);
+            this.textBoxMimicOffset.Location = new System.Drawing.Point(766, 574);
             this.textBoxMimicOffset.Margin = new System.Windows.Forms.Padding(2);
             this.textBoxMimicOffset.Name = "textBoxMimicOffset";
-            this.textBoxMimicOffset.Size = new System.Drawing.Size(66, 20);
+            this.textBoxMimicOffset.Size = new System.Drawing.Size(66, 19);
             this.textBoxMimicOffset.TabIndex = 239;
             this.textBoxMimicOffset.Visible = false;
             // 
             // MimicMultiplierLabel
             // 
             this.MimicMultiplierLabel.AutoSize = true;
-            this.MimicMultiplierLabel.Location = new System.Drawing.Point(704, 599);
+            this.MimicMultiplierLabel.Location = new System.Drawing.Point(704, 553);
             this.MimicMultiplierLabel.Name = "MimicMultiplierLabel";
-            this.MimicMultiplierLabel.Size = new System.Drawing.Size(48, 13);
+            this.MimicMultiplierLabel.Size = new System.Drawing.Size(52, 12);
             this.MimicMultiplierLabel.TabIndex = 240;
             this.MimicMultiplierLabel.Text = "Multiplier";
             this.MimicMultiplierLabel.TextAlign = System.Drawing.ContentAlignment.TopRight;
@@ -1558,9 +1597,9 @@
             // MimicOffsetLabel
             // 
             this.MimicOffsetLabel.AutoSize = true;
-            this.MimicOffsetLabel.Location = new System.Drawing.Point(698, 622);
+            this.MimicOffsetLabel.Location = new System.Drawing.Point(698, 574);
             this.MimicOffsetLabel.Name = "MimicOffsetLabel";
-            this.MimicOffsetLabel.Size = new System.Drawing.Size(59, 13);
+            this.MimicOffsetLabel.Size = new System.Drawing.Size(65, 12);
             this.MimicOffsetLabel.TabIndex = 241;
             this.MimicOffsetLabel.Text = "Offset (rad)";
             this.MimicOffsetLabel.TextAlign = System.Drawing.ContentAlignment.TopRight;
@@ -1570,7 +1609,7 @@
             // 
             this.MimicEquationLabel.AutoSize = true;
             this.MimicEquationLabel.Font = new System.Drawing.Font("Microsoft Sans Serif", 7.8F, System.Drawing.FontStyle.Italic, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.MimicEquationLabel.Location = new System.Drawing.Point(846, 622);
+            this.MimicEquationLabel.Location = new System.Drawing.Point(846, 574);
             this.MimicEquationLabel.Name = "MimicEquationLabel";
             this.MimicEquationLabel.Size = new System.Drawing.Size(171, 13);
             this.MimicEquationLabel.TabIndex = 242;
@@ -1579,9 +1618,9 @@
             // 
             // AssemblyExportForm
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 12F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(1073, 687);
+            this.ClientSize = new System.Drawing.Size(1073, 634);
             this.Controls.Add(this.panelLinkProperties);
             this.Controls.Add(this.buttonJointNext);
             this.Controls.Add(this.buttonJointCancel);
@@ -1663,7 +1702,7 @@
             this.Controls.Add(this.LimitRequiredLabel);
             this.Controls.Add(this.AxisRequiredLabel);
             this.Controls.Add(this.label1);
-            this.MinimumSize = new System.Drawing.Size(1089, 726);
+            this.MinimumSize = new System.Drawing.Size(1089, 673);
             this.Name = "AssemblyExportForm";
             this.Text = "SolidWorks Assembly to URDF Exporter";
             this.Load += new System.EventHandler(this.AssemblyExportFormLoad);
@@ -1673,6 +1712,8 @@
             this.groupBox5.PerformLayout();
             this.groupBox4.ResumeLayout(false);
             this.groupBox4.PerformLayout();
+            this.groupBox1.ResumeLayout(false);
+            this.groupBox1.PerformLayout();
             this.ResumeLayout(false);
             this.PerformLayout();
 
@@ -1831,5 +1872,8 @@
         private System.Windows.Forms.Label MimicMultiplierLabel;
         private System.Windows.Forms.Label MimicOffsetLabel;
         private System.Windows.Forms.Label MimicEquationLabel;
+        private System.Windows.Forms.GroupBox groupBox1;
+        private System.Windows.Forms.RadioButton radioButton3dxml;
+        private System.Windows.Forms.RadioButton radioButtonStl;
     }
 }

--- a/SW2URDF/UI/AssemblyExportForm.cs
+++ b/SW2URDF/UI/AssemblyExportForm.cs
@@ -308,8 +308,20 @@ namespace SW2URDF.UI
 
                 logger.Info("Saving URDF package to " + saveFileDialog1.FileName);
 
-                bool isSTL = radioButtonStl.Checked;
-                Exporter.ExportRobot(exportSTL, isSTL);
+                MeshExportFormat meshFormat;
+                if(radioButtonStl.Checked)
+                {
+                    meshFormat = MeshExportFormat.STL;
+                }
+                else if(radioButton3dxml.Checked)
+                {
+                    meshFormat = MeshExportFormat.THREEDXML;
+                }
+                else
+                {
+                    meshFormat = MeshExportFormat.STL;
+                }
+                Exporter.ExportRobot(exportSTL, meshFormat);
 
                 Close();
             }

--- a/SW2URDF/UI/AssemblyExportForm.cs
+++ b/SW2URDF/UI/AssemblyExportForm.cs
@@ -307,7 +307,10 @@ namespace SW2URDF.UI
                 Exporter.PackageName = Path.GetFileName(saveFileDialog1.FileName);
 
                 logger.Info("Saving URDF package to " + saveFileDialog1.FileName);
-                Exporter.ExportRobot(exportSTL);
+
+                bool isSTL = radioButtonStl.Checked;
+                Exporter.ExportRobot(exportSTL, isSTL);
+
                 Close();
             }
         }

--- a/SW2URDF/URDFExport/ExportHelper.cs
+++ b/SW2URDF/URDFExport/ExportHelper.cs
@@ -29,6 +29,7 @@ using SW2URDF.URDFExport.CSV;
 using SW2URDF.Utilities;
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.IO;
 using System.Windows;
 using System.Xml.Serialization;
@@ -141,7 +142,7 @@ namespace SW2URDF.URDFExport
         #region Export Methods
 
         // Beginning method for exporting the full package
-        public void ExportRobot(bool exportSTL = true)
+        public void ExportRobot(bool exportSTL = true, bool isSTL = true)
         {
             //Setting up the progress bar
             logger.Info("Beginning the export process");
@@ -202,7 +203,7 @@ namespace SW2URDF.URDFExport
             try
             {
                 logger.Info("Beginning individual files export");
-                ExportFiles(URDFRobot.BaseLink, package, 0, exportSTL);
+                ExportFiles(URDFRobot.BaseLink, package, 0, exportSTL, isSTL);
                 success = true;
             }
             catch (Exception e)
@@ -263,7 +264,7 @@ namespace SW2URDF.URDFExport
         }
 
         //Recursive method for exporting each link (and writing it to the URDF)
-        private void ExportFiles(Link link, URDFPackage package, int count, bool exportSTL = true)
+        private void ExportFiles(Link link, URDFPackage package, int count, bool exportSTL = true, bool isSTL = true)
         {
             progressBar.UpdateProgress(count);
             progressBar.UpdateTitle("Exporting mesh: " + link.Name);
@@ -275,7 +276,7 @@ namespace SW2URDF.URDFExport
                 count += 1;
                 if (!child.isFixedFrame)
                 {
-                    ExportFiles(child, package, count, exportSTL);
+                    ExportFiles(child, package, count, exportSTL, isSTL);
                 }
             }
 
@@ -295,16 +296,73 @@ namespace SW2URDF.URDFExport
 
             // Create the mesh filenames. SolidWorks likes to use / but that will get messy in filenames so use _ instead
             string linkName = link.Name.Replace('/', '_');
-            string meshFilename = package.MeshesDirectory + linkName + ".STL";
-            string windowsMeshFileName = package.WindowsMeshesDirectory + linkName + ".STL";
+            string meshFilename = package.MeshesDirectory + linkName;
+            string windowsMeshFileName = package.WindowsMeshesDirectory + linkName;
+            if (isSTL)
+            {
+                meshFilename += ".STL";
+                windowsMeshFileName += ".STL";
+            }
+            else
+            {
+                meshFilename += ".3dxml";
+                windowsMeshFileName += ".3dxml";
+            }
             // Export STL
             if (exportSTL)
             {
-                SaveSTL(link, windowsMeshFileName);
+                if (isSTL)
+                {
+                    SaveSTL(link, windowsMeshFileName);
+                }
+                else
+                {
+                    Save3dxml(link, windowsMeshFileName);
+                }
             }
 
             link.Visual.Geometry.Mesh.Filename = meshFilename;
             link.Collision.Geometry.Mesh.Filename = meshFilename;
+        }
+
+        private void Save3dxml(Link link, string windowsMeshFilename)
+        {
+            int errors = 0;
+            int warnings = 0;
+
+            string coordsysName = link.Joint.CoordinateSystemName;
+
+            logger.Info(link.Name + ": Exporting 3dxml with coordinate frame " + coordsysName);
+
+            Dictionary<string, string> names = GetComponentRefGeoNames(coordsysName);
+            ModelDoc2 ActiveDoc = ActiveSWModel;
+
+            logger.Info(link.Name + ": Reference geometry name " + names["component"]);
+
+            CommonSwOperations.ShowComponents(ActiveSWModel, link.SWComponents);
+
+            int saveOptions = (int)swSaveAsOptions_e.swSaveAsOptions_Silent |
+                (int)swSaveAsOptions_e.swSaveAsOptions_Copy;
+            SetLinkSpecificSTLPreferences(names["geo"], link.STLQualityFine, ActiveDoc);
+
+            logger.Info("Saving 3dxml to " + windowsMeshFilename);
+
+            // === 3dxml Translate Link === //
+            MathTransform coordSysTransform =
+            ActiveSWModel.Extension.GetCoordinateSystemTransformByName(coordsysName);
+            Matrix<double> GlobalTransform = MathOps.GetTransformation(coordSysTransform);
+            LocalizeLink(link, GlobalTransform);
+            // === 3dxml Translate Link === //
+
+            ActiveDoc.Extension.SaveAs(windowsMeshFilename,
+                (int)swSaveAsVersion_e.swSaveAsCurrentVersion, saveOptions, null, ref errors, ref warnings);
+
+            if (errors + warnings != 0)
+            {
+                logger.Warn("Exporting 3dxml for link " + link.Name + " failed with error " + errors +
+                    " or warnings " + warnings);
+            }
+            CommonSwOperations.HideComponents(ActiveSWModel, link.SWComponents);
         }
 
         private bool SaveSTL(Link link, string windowsMeshFilename)

--- a/SW2URDF/URDFExport/ExportHelper.cs
+++ b/SW2URDF/URDFExport/ExportHelper.cs
@@ -360,10 +360,50 @@ namespace SW2URDF.URDFExport
             logger.Info("Saving 3dxml to " + windowsMeshFilename);
 
             // === 3dxml Translate Link === //
+            // MathTransform coordSysTransform =
+            //     ActiveSWModel.Extension.GetCoordinateSystemTransformByName(coordsysName);
+            // ModelDoc2 linkModel = link.SWMainComponent.GetModelDoc2();
+            
+            string linkModelName = names["component"];
+            string linkModelSuffix = " <" + linkModelName + ">";
+            // Coord is inside sub-assembly.
+            if(coordsysName.Contains(linkModelSuffix))
+            {
+                coordsysName = coordsysName.Replace(linkModelSuffix, "");
+                logger.Info($"Suffix of {linkModelName} was removed from coordsysName : {coordsysName}");
+            }
+            // Coord is outside sub-assembly.
+            else
+            {
+                logger.Info($"Did not contain suffix in coordsysName : {coordsysName}");
+            }
+
+            ModelDoc2 linkModel;
+            // The link has no components: Base link
+            if (linkModelName == "")
+            {
+                logger.Info(linkModelName + " : names component null");
+                linkModel = ActiveDoc;
+            }
+            // The link has components: Sub-assembly
+            else
+            {
+                logger.Info(linkModelName + " : names component is : " + names["component"]);
+                linkModel = link.SWMainComponent.GetModelDoc2();
+            }
             MathTransform coordSysTransform =
-            ActiveSWModel.Extension.GetCoordinateSystemTransformByName(coordsysName);
-            Matrix<double> GlobalTransform = MathOps.GetTransformation(coordSysTransform);
-            LocalizeLink(link, GlobalTransform);
+                linkModel.Extension.GetCoordinateSystemTransformByName(coordsysName);
+
+            if (coordSysTransform != null)
+            {
+                logger.Info("Localizing Link : " + coordsysName);
+                Matrix<double> GlobalTransform = MathOps.GetTransformation(coordSysTransform);
+                LocalizeLink(link, GlobalTransform);
+            }
+            else
+            {
+                logger.Warn("coordSysTransform was null : " + coordsysName);
+            }
             // === 3dxml Translate Link === //
 
             ActiveDoc.Extension.SaveAs(windowsMeshFilename,

--- a/SW2URDF/URDFExport/ExportHelper.cs
+++ b/SW2URDF/URDFExport/ExportHelper.cs
@@ -142,7 +142,7 @@ namespace SW2URDF.URDFExport
         #region Export Methods
 
         // Beginning method for exporting the full package
-        public void ExportRobot(bool exportSTL = true, bool isSTL = true)
+        public void ExportRobot(bool exportSTL = true, MeshExportFormat meshFormat = MeshExportFormat.STL)
         {
             //Setting up the progress bar
             logger.Info("Beginning the export process");
@@ -203,7 +203,7 @@ namespace SW2URDF.URDFExport
             try
             {
                 logger.Info("Beginning individual files export");
-                ExportFiles(URDFRobot.BaseLink, package, 0, exportSTL, isSTL);
+                ExportFiles(URDFRobot.BaseLink, package, 0, exportSTL, meshFormat);
                 success = true;
             }
             catch (Exception e)
@@ -264,7 +264,7 @@ namespace SW2URDF.URDFExport
         }
 
         //Recursive method for exporting each link (and writing it to the URDF)
-        private void ExportFiles(Link link, URDFPackage package, int count, bool exportSTL = true, bool isSTL = true)
+        private void ExportFiles(Link link, URDFPackage package, int count, bool exportSTL = true, MeshExportFormat meshFormat = MeshExportFormat.STL)
         {
             progressBar.UpdateProgress(count);
             progressBar.UpdateTitle("Exporting mesh: " + link.Name);
@@ -276,7 +276,7 @@ namespace SW2URDF.URDFExport
                 count += 1;
                 if (!child.isFixedFrame)
                 {
-                    ExportFiles(child, package, count, exportSTL, isSTL);
+                    ExportFiles(child, package, count, exportSTL, meshFormat);
                 }
             }
 
@@ -298,29 +298,41 @@ namespace SW2URDF.URDFExport
             string linkName = link.Name.Replace('/', '_');
             string meshFilename = package.MeshesDirectory + linkName;
             string windowsMeshFileName = package.WindowsMeshesDirectory + linkName;
-            if (isSTL)
+            switch(meshFormat)
             {
-                meshFilename += ".STL";
-                windowsMeshFileName += ".STL";
-            }
-            else
-            {
-                meshFilename += ".3dxml";
-                windowsMeshFileName += ".3dxml";
+                case MeshExportFormat.STL:
+                    meshFilename += ".STL";
+                    windowsMeshFileName += ".STL";
+                    break;
+
+                case MeshExportFormat.THREEDXML:
+                    meshFilename += ".3dxml";
+                    windowsMeshFileName += ".3dxml";
+                    break;
+
+                default:
+                    meshFilename += ".STL";
+                    windowsMeshFileName += ".STL";
+                    break;
             }
             // Export STL
             if (exportSTL)
             {
-                if (isSTL)
+                switch (meshFormat)
                 {
-                    SaveSTL(link, windowsMeshFileName);
-                }
-                else
-                {
-                    Save3dxml(link, windowsMeshFileName);
+                    case MeshExportFormat.STL:
+                        SaveSTL(link, windowsMeshFileName);
+                        break;
+
+                    case MeshExportFormat.THREEDXML:
+                        Save3dxml(link, windowsMeshFileName);
+                        break;
+
+                    default:
+                        SaveSTL(link, windowsMeshFileName);
+                        break;
                 }
             }
-
             link.Visual.Geometry.Mesh.Filename = meshFilename;
             link.Collision.Geometry.Mesh.Filename = meshFilename;
         }

--- a/SW2URDF/URDFExport/ExportHelperExtension.cs
+++ b/SW2URDF/URDFExport/ExportHelperExtension.cs
@@ -1417,4 +1417,10 @@ namespace SW2URDF.URDFExport
 
         #endregion Joint methods
     }
+
+    public enum MeshExportFormat
+    {
+        STL,
+        THREEDXML
+    }
 }


### PR DESCRIPTION
This PR allows the URDF exporter to output mesh files not only in STL format but also in 3DXML format. This enables the export of models with color information.
This does not destroy the original functions.

This solves this issue.
https://github.com/ros/solidworks_urdf_exporter/issues/114

![image](https://github.com/ros/solidworks_urdf_exporter/assets/79335866/c133615c-1a05-42a7-875f-7f21f0bacfb3)

### Exported in STL (no color)
![grayscale](https://github.com/ros/solidworks_urdf_exporter/assets/79335866/07448d93-5d90-4e24-b363-74a947b258b4)

### Exported in 3dxml (with color)
![color](https://github.com/ros/solidworks_urdf_exporter/assets/79335866/e4d43ee8-396e-44c8-b795-a7161e0b1345)

## How to convert to .dae format for ros
 
```
pip3 install scikit-robot -U
convert-urdf-mesh <URDF_PATH> --output <OUTPUT_URDF_PATH>
```
