### PR TITLE
fix math issue in GetRPY function that generates incorrect roll angles during gimbal lock

### DIFF
--- a/SW2URDF/Test/TestMathOps.cs
+++ b/SW2URDF/Test/TestMathOps.cs
@@ -228,6 +228,18 @@ namespace SW2URDF.Test
         [InlineData(
             new double[] { 0, 1, 0, 0, -1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1 }, 
             new double[] { 0, 0, Math.PI / 2.0 })]
+        [InlineData(
+            new double[] { 0, 0, 1, 0, 0, 1, 0, 0, -1, 0, 0, 0, 0, 0, 0, 1 }, 
+            new double[] { 0, -Math.PI / 2.0, 0 })]
+        [InlineData(
+            new double[] { 0, 0, -1, 0, -1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 1 }, 
+            new double[] { -Math.PI / 2.0, Math.PI / 2.0, 0 })]
+        [InlineData(
+            new double[] { 0, 0, 1, 0, 0.7071067811865476, 0.7071067811865476, 0, 0, -0.7071067811865476, 0.7071067811865476, 0, 0, 0, 0, 0, 1 }, 
+            new double[] { -Math.PI / 4.0, -Math.PI / 2.0, 0 })]
+        [InlineData(
+            new double[] { 0, 0, 1, 0, -0.7071067811865476, -0.7071067811865476, 0, 0, 0.7071067811865476, -0.7071067811865476, 0, 0, 0, 0, 0, 1 }, 
+            new double[] { 3 * Math.PI / 4.0, -Math.PI / 2.0, 0 })]
         public void TestGetRPYDenseMatrix(double[] matrixData, double[] expected)
         {
             Matrix<double> m = new DenseMatrix(4, 4, matrixData);
@@ -268,6 +280,18 @@ namespace SW2URDF.Test
         [InlineData(
             new double[] { 0, 0, Math.PI / 2.0 },
             new double[] { 0, 1, 0, 0, -1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1 })]
+        [InlineData(
+            new double[] { 0, -Math.PI / 2.0, 0 },
+            new double[] { 0, 0, 1, 0, 0, 1, 0, 0, -1, 0, 0, 0, 0, 0, 0, 1 })]
+        [InlineData(
+            new double[] { -Math.PI / 2.0, Math.PI / 2.0, 0 },
+            new double[] { 0, 0, -1, 0, -1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 1 })]
+        [InlineData(
+            new double[] { -Math.PI / 4.0, -Math.PI / 2.0, 0 },
+            new double[] { 0, 0, 1, 0, 0.7071067811865476, 0.7071067811865476, 0, 0, -0.7071067811865476, 0.7071067811865476, 0, 0, 0, 0, 0, 1 })]
+        [InlineData(
+            new double[] { 3 * Math.PI / 4.0, -Math.PI / 2.0, 0 },
+            new double[] { 0, 0, 1, 0, -0.7071067811865476, -0.7071067811865476, 0, 0, 0.7071067811865476, -0.7071067811865476, 0, 0, 0, 0, 0, 1 })]
         public void TestGetRotation(double[] rpy, double[] expected)
         {
             double[] result = MathOps.GetRotation(rpy).AsColumnMajorArray();

--- a/SW2URDF/Utilities/MathOPS.cs
+++ b/SW2URDF/Utilities/MathOPS.cs
@@ -156,14 +156,11 @@ namespace SW2URDF.Utilities
         public static double[] GetRPY(Matrix<double> m)
         {
             double roll, pitch, yaw;
-            double x, y;
-            x = Math.Min(1.0, Math.Abs(m[2, 0])) * Math.Sign(m[2, 0]);
-            y = Math.Min(1.0, Math.Abs(m[0, 2])) * Math.Sign(m[0, 2]);
             if (Math.Abs(m[2, 0]) >= 1.0)
             {
-                // Gimbol Lock
-                pitch = -Math.Asin(x);
-                roll = Math.Acos(y);
+                // Gimbal Lock
+                pitch = -Math.Asin(Math.Sign(m[2, 0]) * 1.0);
+                roll = Math.Atan2(-m[1, 2], m[1, 1]);
                 yaw = 0;
             }
             else


### PR DESCRIPTION
This PR fixes a subtle mathematical issue in the **GetRPY** function in MathOps.cs that has been producing incorrect roll angles in some cases where gimbal lock occurs. 

This problem typically does not become apparent until we try to load a robot model from the generated URDF using some other library, package, simulator, etc., and find that it differs from our Solidworks assembly. I've attached an example Solidworks assembly which shows this issue, and you can verify that with this PR, we can now produce a URDF package that matches the Solidworks model. I've also built and run all the unit tests locally, and they all pass. 

Since dealing with 3D rotation representations can be a considerable headache, and it helps to be precise, I've attached a PDF writeup where I've tried to describe the math issue in detail: [SW2URDF_Modifications.pdf](https://github.com/user-attachments/files/20015375/SW2URDF_Modifications.pdf)

The TLDR is that when gimbal lock occurs, the way we use arccos to compute the roll angle leads to issues, both because the argument passed to arccos couples the sign of _sin(pitch)_ together with _cos(roll)_, and because the range of arccos is only [0, pi] which means we cannot compute roll angles that have negative _sin(roll)_, as is sometimes needed. The solution in the PR is to instead use the atan2 function, and pass different entries from the rotation matrix as arguments. 

The way we can verify this is really an issue, as opposed to some convention disagreement, is to recognize that rotation matrices are unique and to consider cases where conversion from (_rotation matrix -> RPY -> rotation matrix_) fails to preserve the rotation matrix (if the first mapping _rotation matrix -> RPY_ comes from the **GetRPY** function).

Here's the example model, a simple robot torso/arm, that shows the issue in question. In the Solidworks assembly (see attached), the model looks like this:
![rpy_issue_demo_CAD](https://github.com/user-attachments/assets/25250263-9b8a-45f5-a0e1-12e8a059928a)

However, when we export this assembly to a URDF package and load it in a URDF viewer, we find this:
![rpy_issue_demo_URDF_export_v1](https://github.com/user-attachments/assets/96a39472-8066-4c36-9b73-3b5896e831b5)

This happens because Frame 2 and Frame 3 are used as the reference coordinate systems for two of the bodies in the URDF exporter, and the transform between Frame 2 and Frame 3 triggers the **GetRPY** error, so we compute the wrong roll angle. Then the URDF viewer internally constructs some rotation representation (likely rotation matrices) from the rpy angles we generated, and the two models disagree.

With the fix made in this PR we can export the URDF package, visualize it, and find it agrees with the Solidworks assembly, as shown below:
![rpy_issue_demo_URDF_export_v2](https://github.com/user-attachments/assets/9b360128-5108-4629-a1b9-98d7dbaa6540)
 
Solidworks assembly: 
[rpy_issue_demo_assembly.zip](https://github.com/user-attachments/files/20015435/rpy_issue_demo_assembly.zip)