### PR TITLE
fix System.NullReferenceException when use limit mate

### DIFF
--- a/SW2URDF/SW2URDF.csproj
+++ b/SW2URDF/SW2URDF.csproj
@@ -164,6 +164,7 @@
     <CodeAnalysisRuleSet>SW2URDF.ruleset</CodeAnalysisRuleSet>
     <RunCodeAnalysis>true</RunCodeAnalysis>
     <Prefer32Bit>false</Prefer32Bit>
+    <LangVersion>7.1</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
     <DebugSymbols>true</DebugSymbols>

--- a/SW2URDF/URDFExport/ExportHelperExtension.cs
+++ b/SW2URDF/URDFExport/ExportHelperExtension.cs
@@ -1256,14 +1256,26 @@ namespace SW2URDF.URDFExport
                 {
                     MateEntity2 entity = swMate.MateEntity(i);
                     entities.Add(entity.ReferenceComponent);
-                    logger.Info("Adding component entity: " + entity.ReferenceComponent.Name2);
-
-                    Component2 parent = entity.ReferenceComponent.GetParent();
-                    while (parent != null)
+                    if (entity.ReferenceComponent != null)
                     {
-                        logger.Info("Adding component entity: " + parent.Name2);
-                        entities.Add(parent);
-                        parent = parent.GetParent();
+                        if (entity.ReferenceComponent.Name2 != null)
+                        {
+                            logger.Info("Adding component entity: " + entity.ReferenceComponent.Name2);
+                        }
+                        Component2 parent = entity.ReferenceComponent.GetParent();
+                        while (parent != null)
+                        {
+                            if (parent.Name2 != null)
+                            {
+                                logger.Info("Adding component entity: " + parent.Name2);
+                            }
+                            entities.Add(parent);
+                            parent = parent.GetParent();
+                        }
+                    }
+                    else
+                    {
+                        logger.Warn("Mate entity has no reference component");
                     }
                 }
 

--- a/SW2URDF/URDFExport/ExportHelperExtension.cs
+++ b/SW2URDF/URDFExport/ExportHelperExtension.cs
@@ -1255,27 +1255,23 @@ namespace SW2URDF.URDFExport
                 for (int i = 0; i < swMate.GetMateEntityCount(); i++)
                 {
                     MateEntity2 entity = swMate.MateEntity(i);
-                    entities.Add(entity.ReferenceComponent);
-                    if (entity.ReferenceComponent != null)
-                    {
-                        if (entity.ReferenceComponent.Name2 != null)
-                        {
-                            logger.Info("Adding component entity: " + entity.ReferenceComponent.Name2);
-                        }
-                        Component2 parent = entity.ReferenceComponent.GetParent();
-                        while (parent != null)
-                        {
-                            if (parent.Name2 != null)
-                            {
-                                logger.Info("Adding component entity: " + parent.Name2);
-                            }
-                            entities.Add(parent);
-                            parent = parent.GetParent();
-                        }
-                    }
-                    else
+                    
+                    // Check if entity.ReferenceComponent is null and skip if so
+                    if (entity.ReferenceComponent == null)
                     {
                         logger.Warn("Mate entity has no reference component");
+                        continue;
+                    }
+                    
+                    entities.Add(entity.ReferenceComponent);
+                    logger.Info("Adding component entity: " + entity.ReferenceComponent.Name2);
+
+                    Component2 parent = entity.ReferenceComponent.GetParent();
+                    while (parent != null)
+                    {
+                        logger.Info("Adding component entity: " + parent.Name2);
+                        entities.Add(parent);
+                        parent = parent.GetParent();
                     }
                 }
 


### PR DESCRIPTION
When I click **Preview and Export...** button in Property Manager, I get the error similar to the following:

```
2025-09-17 14:36:08,351 INFO  ExportHelperExtension.cs: 1247 - Parent SW Component: DDB6000.1 行走底盘(默认)-1/底盘-2
2025-09-17 14:36:08,351 INFO  ExportHelperExtension.cs: 1248 - Child SW Component: DDB6000.1 行走底盘(默认)-1/DDB6000.1.1 板材叉车-1/DDB6000.1.1.1 水平导轨组-2
2025-09-17 14:36:08,351 INFO  ExportHelperExtension.cs: 1253 - Determining limit mate eligibility 
2025-09-17 14:36:08,378 WARN  ExportHelperExtension.cs: 1268 - Mate entity has no reference component
2025-09-17 14:36:08,440 ERROR ExportPropertyManager.cs: 399 - Exception caught handling button press 17
System.NullReferenceException: 未将对象引用设置到对象的实例。
   在 SW2URDF.URDFExport.ExportHelper.AddLimits(Joint Joint, List`1 limitMates, Component2 parentComponent, Component2 childComponent) 位置 C:\Users\wsxq2\Downloads\solidworks_urdf_exporter\SW2URDF\URDFExport\ExportHelperExtension.cs:行号 1271
   在 SW2URDF.URDFExport.ExportHelper.EstimateGlobalJointFromComponents(Link parent, Link child) 位置 C:\Users\wsxq2\Downloads\solidworks_urdf_exporter\SW2URDF\URDFExport\ExportHelperExtension.cs:行号 892
   在 SW2URDF.URDFExport.ExportHelper.CreateJoint(Link parent, Link child) 位置 C:\Users\wsxq2\Downloads\solidworks_urdf_exporter\SW2URDF\URDFExport\ExportHelperExtension.cs:行号 425
   在 SW2URDF.URDFExport.ExportHelper.CreateLinkFromComponents(Link parent, LinkNode node) 位置 C:\Users\wsxq2\Downloads\solidworks_urdf_exporter\SW2URDF\URDFExport\ExportHelperExtension.cs:行号 348
   在 SW2URDF.URDFExport.ExportHelper.CreateLink(LinkNode node, Int32 count) 位置 C:\Users\wsxq2\Downloads\solidworks_urdf_exporter\SW2URDF\URDFExport\ExportHelperExtension.cs:行号 215
   在 SW2URDF.URDFExport.ExportHelper.CreateLink(LinkNode node, Int32 count) 位置 C:\Users\wsxq2\Downloads\solidworks_urdf_exporter\SW2URDF\URDFExport\ExportHelperExtension.cs:行号 227
   在 SW2URDF.URDFExport.ExportHelper.CreateRobotFromTreeView(LinkNode baseNode) 位置 C:\Users\wsxq2\Downloads\solidworks_urdf_exporter\SW2URDF\URDFExport\ExportHelperExtension.cs:行号 169
   在 SW2URDF.URDFExport.ExportPropertyManager.ExportButtonPress() 位置 C:\Users\wsxq2\Downloads\solidworks_urdf_exporter\SW2URDF\URDFExport\ExportPropertyManager.cs:行号 239
   在 SW2URDF.URDFExport.ExportPropertyManager.OnButtonPress(Int32 Id) 位置 C:\Users\wsxq2\Downloads\solidworks_urdf_exporter\SW2URDF\URDFExport\ExportPropertyManager.cs:行号 381
   在 SW2URDF.URDFExport.ExportPropertyManager.SolidWorks.Interop.swpublished.IPropertyManagerPage2Handler9.OnButtonPress(Int32 Id) 位置 C:\Users\wsxq2\Downloads\solidworks_urdf_exporter\SW2URDF\URDFExport\ExportPropertyManager.cs:行号 399
2025-09-17 14:36:08,491 INFO  ExportPropertyManager.cs: 1142 - AfterClose called. This method no longer throws an Exception. It just silently does nothing. Ok, except for this logging message
```

Note: This log is generated after I changing some code, so line number may have some difference with origin source code.

When I dig into the code, I found there is no check for null reference. After adding related code (ie. this PR), the above problem is disapear, and generated package is working fine.

Another change in `SW2URDF/SW2URDF.csproj` is because that the latest Visual Studio 2017 need set `LangVersion` to compiling successfully.