### PR TITLE
fix: joint mimic unchecking not working after checked.

### DIFF
--- a/SW2URDF/UI/AssemblyExportFormExtension.cs
+++ b/SW2URDF/UI/AssemblyExportFormExtension.cs
@@ -343,6 +343,10 @@ namespace SW2URDF.UI
             {
                 Joint.Mimic.Update(MimicJointComboBox.Text, textBoxMimicMultiplier.Text, textBoxMimicOffset.Text);
             }
+            else
+            {
+                Joint.Mimic.Clear();
+            }
         }
 
         //Fills specifically the joint TreeView

--- a/SW2URDF/URDF/Mimic.cs
+++ b/SW2URDF/URDF/Mimic.cs
@@ -76,6 +76,13 @@ namespace SW2URDF.URDF
             OffsetAttribute.SetDoubleValueFromString(offsetText);
         }
 
+        public void Clear()
+        {
+            JointNameAttribute.Value = null;
+            MultiplierAttribute.Value = null;
+            OffsetAttribute.Value = null;
+        }
+
         internal void FillBoxes(TextBox textBoxMimicMultiplier, TextBox textBoxMimicOffset)
         {
             textBoxMimicMultiplier.Text = MultiplierAttribute.GetTextFromDoubleValue();


### PR DESCRIPTION
When I use mimic checkbox in joint setting, I find that after checking, and set joint name, then exporting is normal, but after I unchecked the mimic checkbox, the exported urdf still including the mimic tag and related attribute.

After I dig into the code, I find there is no related code, so I add it. 

While reading the code, I found that the C# language is quite interesting, and the code of this project is amazing, It implements far more functionality than described in the documentation.