### PR TITLE
ROS 2 export, STL coordinate fix, and full-depth reference geometry

### DIFF
--- a/SW2URDF/ROS/ROS2Files.cs
+++ b/SW2URDF/ROS/ROS2Files.cs
@@ -22,7 +22,10 @@ THE SOFTWARE.
 
 using log4net;
 using SW2URDF.Utilities;
+using System;
 using System.IO;
+using System.Text;
+using System.Text.RegularExpressions;
 
 namespace SW2URDF.ROS
 {
@@ -39,6 +42,45 @@ namespace SW2URDF.ROS
     public static class ROS2Files
     {
         private static readonly ILog logger = Logger.GetLogger();
+
+        // Coerce a name into a valid ROS 2 / colcon package name: lowercase, only [a-z0-9_],
+        // starts with a letter, no doubled or edge underscores. Strips a trailing SolidWorks
+        // extension (e.g. a default package name of "3_DOF_ARM.SLDASM" becomes "pkg_3_dof_arm").
+        public static string SanitizePackageName(string name)
+        {
+            if (string.IsNullOrWhiteSpace(name))
+            {
+                return "robot_description";
+            }
+
+            string s = name.Trim();
+            foreach (string ext in new[] { ".sldasm", ".sldprt" })
+            {
+                if (s.EndsWith(ext, StringComparison.OrdinalIgnoreCase))
+                {
+                    s = s.Substring(0, s.Length - ext.Length);
+                    break;
+                }
+            }
+
+            s = s.ToLowerInvariant();
+            StringBuilder sb = new StringBuilder(s.Length);
+            foreach (char c in s)
+            {
+                sb.Append((c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') ? c : '_');
+            }
+
+            string result = Regex.Replace(sb.ToString(), "_+", "_").Trim('_');
+            if (result.Length == 0)
+            {
+                return "robot_description";
+            }
+            if (!char.IsLetter(result[0]))
+            {
+                result = "pkg_" + result;
+            }
+            return result;
+        }
 
         // ament_cmake package manifest (package.xml, format 3).
         public static void WritePackageXML(string savePath, string packageName)

--- a/SW2URDF/ROS/ROS2Files.cs
+++ b/SW2URDF/ROS/ROS2Files.cs
@@ -1,0 +1,180 @@
+/*
+Copyright (c) 2015 Stephen Brawner
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+using log4net;
+using SW2URDF.Utilities;
+using System.IO;
+
+namespace SW2URDF.ROS
+{
+    // Selects which ROS ecosystem the exported package scaffold targets.
+    public enum ROSVersion
+    {
+        ROS1,
+        ROS2,
+    }
+
+    // Writes the ROS 2 (ament_cmake) flavour of the package scaffold: package.xml
+    // (format 3), CMakeLists.txt and Python launch files. ROS 1 output is left
+    // untouched in URDFPackage / PackageXMLWriter / ROSFiles.
+    public static class ROS2Files
+    {
+        private static readonly ILog logger = Logger.GetLogger();
+
+        // ament_cmake package manifest (package.xml, format 3).
+        public static void WritePackageXML(string savePath, string packageName)
+        {
+            logger.Info("Creating ROS 2 package.xml at " + savePath);
+            using (StreamWriter file = new StreamWriter(savePath))
+            {
+                file.WriteLine("<?xml version=\"1.0\"?>");
+                file.WriteLine("<?xml-model href=\"http://download.ros.org/schema/package_format3.xsd\" " +
+                    "schematypens=\"http://www.w3.org/2001/XMLSchema\"?>");
+                file.WriteLine("<package format=\"3\">");
+                file.WriteLine("  <name>" + packageName + "</name>");
+                file.WriteLine("  <version>1.0.0</version>");
+                file.WriteLine("  <description>URDF Description package for " + packageName + "</description>");
+                file.WriteLine("  <maintainer email=\"todo@todo.todo\">TODO</maintainer>");
+                file.WriteLine("  <license>BSD</license>");
+                file.WriteLine();
+                file.WriteLine("  <buildtool_depend>ament_cmake</buildtool_depend>");
+                file.WriteLine();
+                file.WriteLine("  <exec_depend>robot_state_publisher</exec_depend>");
+                file.WriteLine("  <exec_depend>joint_state_publisher_gui</exec_depend>");
+                file.WriteLine("  <exec_depend>rviz2</exec_depend>");
+                file.WriteLine("  <exec_depend>xacro</exec_depend>");
+                file.WriteLine("  <exec_depend>launch</exec_depend>");
+                file.WriteLine("  <exec_depend>launch_ros</exec_depend>");
+                file.WriteLine();
+                file.WriteLine("  <export>");
+                file.WriteLine("    <build_type>ament_cmake</build_type>");
+                file.WriteLine("  </export>");
+                file.WriteLine("</package>");
+            }
+        }
+
+        // ament_cmake CMakeLists.txt that installs the resource directories.
+        public static void WriteCMakeLists(string savePath, string packageName)
+        {
+            logger.Info("Creating ROS 2 CMakeLists.txt at " + savePath);
+            using (StreamWriter file = new StreamWriter(savePath))
+            {
+                file.WriteLine("cmake_minimum_required(VERSION 3.8)");
+                file.WriteLine("project(" + packageName + ")");
+                file.WriteLine();
+                file.WriteLine("find_package(ament_cmake REQUIRED)");
+                file.WriteLine();
+                file.WriteLine("install(DIRECTORY config launch meshes textures urdf");
+                file.WriteLine("  DESTINATION share/${PROJECT_NAME})");
+                file.WriteLine();
+                file.WriteLine("ament_package()");
+            }
+        }
+
+        // Python launch file: robot_state_publisher + joint_state_publisher_gui + rviz2.
+        public static void WriteDisplayLaunch(string launchDir, string packageName, string robotURDF)
+        {
+            string savePath = launchDir + "display.launch.py";
+            logger.Info("Creating ROS 2 display launch at " + savePath);
+            using (StreamWriter file = new StreamWriter(savePath))
+            {
+                file.WriteLine("import os");
+                file.WriteLine();
+                file.WriteLine("from ament_index_python.packages import get_package_share_directory");
+                file.WriteLine("from launch import LaunchDescription");
+                file.WriteLine("from launch.actions import DeclareLaunchArgument");
+                file.WriteLine("from launch.substitutions import Command, LaunchConfiguration");
+                file.WriteLine("from launch_ros.actions import Node");
+                file.WriteLine("from launch_ros.parameter_descriptions import ParameterValue");
+                file.WriteLine();
+                file.WriteLine();
+                file.WriteLine("def generate_launch_description():");
+                file.WriteLine("    pkg_share = get_package_share_directory('" + packageName + "')");
+                file.WriteLine("    default_model = os.path.join(pkg_share, 'urdf', '" + robotURDF + "')");
+                file.WriteLine("    default_rviz = os.path.join(pkg_share, 'urdf.rviz')");
+                file.WriteLine();
+                file.WriteLine("    robot_description = ParameterValue(");
+                file.WriteLine("        Command(['xacro ', LaunchConfiguration('model')]), value_type=str)");
+                file.WriteLine();
+                file.WriteLine("    return LaunchDescription([");
+                file.WriteLine("        DeclareLaunchArgument(name='model', default_value=default_model),");
+                file.WriteLine("        DeclareLaunchArgument(name='rvizconfig', default_value=default_rviz),");
+                file.WriteLine("        Node(");
+                file.WriteLine("            package='robot_state_publisher',");
+                file.WriteLine("            executable='robot_state_publisher',");
+                file.WriteLine("            parameters=[{'robot_description': robot_description}],");
+                file.WriteLine("        ),");
+                file.WriteLine("        Node(");
+                file.WriteLine("            package='joint_state_publisher_gui',");
+                file.WriteLine("            executable='joint_state_publisher_gui',");
+                file.WriteLine("        ),");
+                file.WriteLine("        Node(");
+                file.WriteLine("            package='rviz2',");
+                file.WriteLine("            executable='rviz2',");
+                file.WriteLine("            output='screen',");
+                file.WriteLine("            arguments=['-d', LaunchConfiguration('rvizconfig')],");
+                file.WriteLine("        ),");
+                file.WriteLine("    ])");
+            }
+        }
+
+        // Python launch file: bring up the robot in Gazebo (gazebo_ros) and spawn it.
+        public static void WriteGazeboLaunch(string launchDir, string packageName, string robotURDF, string modelName)
+        {
+            string savePath = launchDir + "gazebo.launch.py";
+            logger.Info("Creating ROS 2 gazebo launch at " + savePath);
+            using (StreamWriter file = new StreamWriter(savePath))
+            {
+                file.WriteLine("import os");
+                file.WriteLine();
+                file.WriteLine("from ament_index_python.packages import get_package_share_directory");
+                file.WriteLine("from launch import LaunchDescription");
+                file.WriteLine("from launch.actions import IncludeLaunchDescription");
+                file.WriteLine("from launch.launch_description_sources import PythonLaunchDescriptionSource");
+                file.WriteLine("from launch_ros.actions import Node");
+                file.WriteLine();
+                file.WriteLine();
+                file.WriteLine("def generate_launch_description():");
+                file.WriteLine("    pkg_share = get_package_share_directory('" + packageName + "')");
+                file.WriteLine("    urdf = os.path.join(pkg_share, 'urdf', '" + robotURDF + "')");
+                file.WriteLine("    gazebo_ros_share = get_package_share_directory('gazebo_ros')");
+                file.WriteLine();
+                file.WriteLine("    return LaunchDescription([");
+                file.WriteLine("        IncludeLaunchDescription(");
+                file.WriteLine("            PythonLaunchDescriptionSource(");
+                file.WriteLine("                os.path.join(gazebo_ros_share, 'launch', 'gazebo.launch.py'))),");
+                file.WriteLine("        Node(");
+                file.WriteLine("            package='robot_state_publisher',");
+                file.WriteLine("            executable='robot_state_publisher',");
+                file.WriteLine("            arguments=[urdf],");
+                file.WriteLine("        ),");
+                file.WriteLine("        Node(");
+                file.WriteLine("            package='gazebo_ros',");
+                file.WriteLine("            executable='spawn_entity.py',");
+                file.WriteLine("            arguments=['-entity', '" + modelName + "', '-file', urdf],");
+                file.WriteLine("            output='screen',");
+                file.WriteLine("        ),");
+                file.WriteLine("    ])");
+            }
+        }
+    }
+}

--- a/SW2URDF/SW2URDF.csproj
+++ b/SW2URDF/SW2URDF.csproj
@@ -345,6 +345,7 @@
       <DependentUpon>Resources.resx</DependentUpon>
     </Compile>
     <Compile Include="ROS\ROSFiles.cs" />
+    <Compile Include="ROS\ROS2Files.cs" />
     <Compile Include="UI\TreeMergedEventArgs.cs" />
     <Compile Include="UI\TreeMergeWPF.xaml.cs">
       <DependentUpon>TreeMergeWPF.xaml</DependentUpon>

--- a/SW2URDF/SW2URDF.csproj
+++ b/SW2URDF/SW2URDF.csproj
@@ -28,6 +28,9 @@
     <DelaySign>false</DelaySign>
     <OutputType>Library</OutputType>
     <RootNamespace>SW2URDF</RootNamespace>
+    <!-- SolidWorks install dir, used to locate the interop assemblies. Override with
+         /p:SolidWorksDir=... or a SolidWorksDir env var if installed elsewhere. -->
+    <SolidWorksDir Condition=" '$(SolidWorksDir)' == '' ">C:\Program Files\SOLIDWORKS Corp\SOLIDWORKS\</SolidWorksDir>
     <RunPostBuildEvent>OnBuildSuccess</RunPostBuildEvent>
     <StartupObject>
     </StartupObject>
@@ -37,7 +40,7 @@
     </UpgradeBackupLocation>
     <StartProgram>C:\PROGRA~1\SOLIDW~1\SOLIDW~1\\SldWorks.exe</StartProgram>
     <StartAction>Program</StartAction>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <OldToolsVersion>2.0</OldToolsVersion>
     <IsWebBootstrapper>false</IsWebBootstrapper>
     <TargetFrameworkProfile>
@@ -253,20 +256,20 @@
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
     <Reference Include="SolidWorks.Interop.sldworks">
-      <HintPath>..\..\..\..\..\Program Files\SOLIDWORKS Corp\SOLIDWORKS\SolidWorks.Interop.sldworks.dll</HintPath>
+      <HintPath>$(SolidWorksDir)SolidWorks.Interop.sldworks.dll</HintPath>
       <EmbedInteropTypes>True</EmbedInteropTypes>
     </Reference>
     <Reference Include="SolidWorks.Interop.swconst">
-      <HintPath>..\..\..\..\..\Program Files\SOLIDWORKS Corp\SOLIDWORKS\SolidWorks.Interop.swconst.dll</HintPath>
+      <HintPath>$(SolidWorksDir)SolidWorks.Interop.swconst.dll</HintPath>
       <EmbedInteropTypes>True</EmbedInteropTypes>
     </Reference>
     <Reference Include="SolidWorks.Interop.swpublished">
-      <HintPath>..\..\..\..\..\Program Files\SOLIDWORKS Corp\SOLIDWORKS\SolidWorks.Interop.swpublished.dll</HintPath>
+      <HintPath>$(SolidWorksDir)SolidWorks.Interop.swpublished.dll</HintPath>
       <EmbedInteropTypes>True</EmbedInteropTypes>
     </Reference>
     <Reference Include="solidworkstools, Version=2.0.0.0, Culture=neutral, PublicKeyToken=bd18593873b4686d, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\..\Program Files\SOLIDWORKS Corp\SOLIDWORKS\solidworkstools.dll</HintPath>
+      <HintPath>$(SolidWorksDir)solidworkstools.dll</HintPath>
     </Reference>
     <Reference Include="System">
       <Name>System</Name>
@@ -513,6 +516,7 @@
     <PreBuildEvent>"C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe" -ExecutionPolicy Bypass -File "$(SolutionDir)scripts\UpdateVersionInfo.ps1" --filename "$(ProjectDir)Versioning\VersionInfo.cs"</PreBuildEvent>
     <PostBuildEvent>
 :REGISTRATION
+IF "$(TargetFrameworkVersion)"=="v4.8" GOTO NET40
 IF "$(TargetFrameworkVersion)"=="v4.5.2" GOTO NET40
 IF "$(TargetFrameworkVersion)"=="v4.5" GOTO NET40
 IF "$(TargetFrameworkVersion)"=="v4.0" GOTO NET40

--- a/SW2URDF/UI/AssemblyExportForm.Designer.cs
+++ b/SW2URDF/UI/AssemblyExportForm.Designer.cs
@@ -640,7 +640,6 @@
             // radioButtonRos1
             //
             this.radioButtonRos1.AutoSize = true;
-            this.radioButtonRos1.Checked = true;
             this.radioButtonRos1.Location = new System.Drawing.Point(11, 18);
             this.radioButtonRos1.Name = "radioButtonRos1";
             this.radioButtonRos1.Size = new System.Drawing.Size(53, 16);
@@ -652,10 +651,12 @@
             // radioButtonRos2
             //
             this.radioButtonRos2.AutoSize = true;
+            this.radioButtonRos2.Checked = true;
             this.radioButtonRos2.Location = new System.Drawing.Point(11, 44);
             this.radioButtonRos2.Name = "radioButtonRos2";
             this.radioButtonRos2.Size = new System.Drawing.Size(53, 16);
             this.radioButtonRos2.TabIndex = 1;
+            this.radioButtonRos2.TabStop = true;
             this.radioButtonRos2.Text = "ROS 2";
             this.radioButtonRos2.UseVisualStyleBackColor = true;
             //

--- a/SW2URDF/UI/AssemblyExportForm.Designer.cs
+++ b/SW2URDF/UI/AssemblyExportForm.Designer.cs
@@ -71,6 +71,9 @@
             this.groupBox1 = new System.Windows.Forms.GroupBox();
             this.radioButton3dxml = new System.Windows.Forms.RadioButton();
             this.radioButtonStl = new System.Windows.Forms.RadioButton();
+            this.groupBoxRosVersion = new System.Windows.Forms.GroupBox();
+            this.radioButtonRos1 = new System.Windows.Forms.RadioButton();
+            this.radioButtonRos2 = new System.Windows.Forms.RadioButton();
             this.radioButtonFine = new System.Windows.Forms.RadioButton();
             this.radioButtonCourse = new System.Windows.Forms.RadioButton();
             this.label10 = new System.Windows.Forms.Label();
@@ -187,6 +190,7 @@
             this.groupBox5.SuspendLayout();
             this.groupBox4.SuspendLayout();
             this.groupBox1.SuspendLayout();
+            this.groupBoxRosVersion.SuspendLayout();
             this.SuspendLayout();
             // 
             // panelLinkProperties
@@ -550,6 +554,7 @@
             // 
             this.groupBox4.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.groupBox4.Controls.Add(this.groupBox1);
+            this.groupBox4.Controls.Add(this.groupBoxRosVersion);
             this.groupBox4.Controls.Add(this.radioButtonFine);
             this.groupBox4.Controls.Add(this.radioButtonCourse);
             this.groupBox4.Controls.Add(this.label10);
@@ -620,9 +625,42 @@
             this.radioButtonStl.TabStop = true;
             this.radioButtonStl.Text = "STL (grayscale)";
             this.radioButtonStl.UseVisualStyleBackColor = true;
-            // 
+            //
+            // groupBoxRosVersion
+            //
+            this.groupBoxRosVersion.Controls.Add(this.radioButtonRos2);
+            this.groupBoxRosVersion.Controls.Add(this.radioButtonRos1);
+            this.groupBoxRosVersion.Location = new System.Drawing.Point(315, 160);
+            this.groupBoxRosVersion.Name = "groupBoxRosVersion";
+            this.groupBoxRosVersion.Size = new System.Drawing.Size(122, 70);
+            this.groupBoxRosVersion.TabIndex = 75;
+            this.groupBoxRosVersion.TabStop = false;
+            this.groupBoxRosVersion.Text = "ROS Version";
+            //
+            // radioButtonRos1
+            //
+            this.radioButtonRos1.AutoSize = true;
+            this.radioButtonRos1.Checked = true;
+            this.radioButtonRos1.Location = new System.Drawing.Point(11, 18);
+            this.radioButtonRos1.Name = "radioButtonRos1";
+            this.radioButtonRos1.Size = new System.Drawing.Size(53, 16);
+            this.radioButtonRos1.TabIndex = 0;
+            this.radioButtonRos1.TabStop = true;
+            this.radioButtonRos1.Text = "ROS 1";
+            this.radioButtonRos1.UseVisualStyleBackColor = true;
+            //
+            // radioButtonRos2
+            //
+            this.radioButtonRos2.AutoSize = true;
+            this.radioButtonRos2.Location = new System.Drawing.Point(11, 44);
+            this.radioButtonRos2.Name = "radioButtonRos2";
+            this.radioButtonRos2.Size = new System.Drawing.Size(53, 16);
+            this.radioButtonRos2.TabIndex = 1;
+            this.radioButtonRos2.Text = "ROS 2";
+            this.radioButtonRos2.UseVisualStyleBackColor = true;
+            //
             // radioButtonFine
-            // 
+            //
             this.radioButtonFine.AutoSize = true;
             this.radioButtonFine.Location = new System.Drawing.Point(101, 171);
             this.radioButtonFine.Name = "radioButtonFine";
@@ -1714,6 +1752,8 @@
             this.groupBox4.PerformLayout();
             this.groupBox1.ResumeLayout(false);
             this.groupBox1.PerformLayout();
+            this.groupBoxRosVersion.ResumeLayout(false);
+            this.groupBoxRosVersion.PerformLayout();
             this.ResumeLayout(false);
             this.PerformLayout();
 
@@ -1875,5 +1915,8 @@
         private System.Windows.Forms.GroupBox groupBox1;
         private System.Windows.Forms.RadioButton radioButton3dxml;
         private System.Windows.Forms.RadioButton radioButtonStl;
+        private System.Windows.Forms.GroupBox groupBoxRosVersion;
+        private System.Windows.Forms.RadioButton radioButtonRos1;
+        private System.Windows.Forms.RadioButton radioButtonRos2;
     }
 }

--- a/SW2URDF/UI/AssemblyExportForm.cs
+++ b/SW2URDF/UI/AssemblyExportForm.cs
@@ -22,6 +22,7 @@ THE SOFTWARE.
 
 using SolidWorks.Interop.sldworks;
 using SolidWorks.Interop.swconst;
+using SW2URDF.ROS;
 using SW2URDF.URDF;
 using SW2URDF.URDFExport;
 using SW2URDF.Utilities;
@@ -321,7 +322,9 @@ namespace SW2URDF.UI
                 {
                     meshFormat = MeshExportFormat.STL;
                 }
-                Exporter.ExportRobot(exportSTL, meshFormat);
+
+                ROSVersion rosVersion = radioButtonRos2.Checked ? ROSVersion.ROS2 : ROSVersion.ROS1;
+                Exporter.ExportRobot(exportSTL, meshFormat, rosVersion);
 
                 Close();
             }

--- a/SW2URDF/URDFExport/ExportHelper.cs
+++ b/SW2URDF/URDFExport/ExportHelper.cs
@@ -142,7 +142,8 @@ namespace SW2URDF.URDFExport
         #region Export Methods
 
         // Beginning method for exporting the full package
-        public void ExportRobot(bool exportSTL = true, MeshExportFormat meshFormat = MeshExportFormat.STL)
+        public void ExportRobot(bool exportSTL = true, MeshExportFormat meshFormat = MeshExportFormat.STL,
+            ROSVersion rosVersion = ROSVersion.ROS1)
         {
             //Setting up the progress bar
             logger.Info("Beginning the export process");
@@ -158,31 +159,46 @@ namespace SW2URDF.URDFExport
             string windowsURDFFileName = package.WindowsRobotsDirectory + URDFRobot.Name + ".urdf";
             string windowsCSVFileName = package.WindowsRobotsDirectory + URDFRobot.Name + ".csv";
             string windowsPackageXMLFileName = package.WindowsPackageDirectory + "package.xml";
+            string robotURDF = URDFRobot.Name + ".urdf";
 
-            //Create CMakeLists
-            logger.Info("Creating CMakeLists.txt at " + package.WindowsCMakeLists);
-            package.CreateCMakeLists();
+            if (rosVersion == ROSVersion.ROS2)
+            {
+                // ROS 2 (ament_cmake) scaffold: package.xml format 3, ament CMakeLists and
+                // Python launch files. Geometry/URDF export below is shared with ROS 1.
+                logger.Info("Creating ROS 2 (ament) package scaffold");
+                ROS2Files.WriteCMakeLists(package.WindowsCMakeLists, PackageName);
+                package.CreateConfigYAML(URDFRobot.GetJointNames(false));
+                ROS2Files.WritePackageXML(windowsPackageXMLFileName, PackageName);
+                ROS2Files.WriteDisplayLaunch(package.WindowsLaunchDirectory, PackageName, robotURDF);
+                ROS2Files.WriteGazeboLaunch(package.WindowsLaunchDirectory, PackageName, robotURDF, URDFRobot.Name);
+            }
+            else
+            {
+                //Create CMakeLists
+                logger.Info("Creating CMakeLists.txt at " + package.WindowsCMakeLists);
+                package.CreateCMakeLists();
 
-            //Create Config joint names, not sure how this is used...
-            logger.Info("Creating joint names config at " + package.WindowsConfigYAML);
-            package.CreateConfigYAML(URDFRobot.GetJointNames(false));
+                //Create Config joint names, not sure how this is used...
+                logger.Info("Creating joint names config at " + package.WindowsConfigYAML);
+                package.CreateConfigYAML(URDFRobot.GetJointNames(false));
 
-            //Creating package.xml file
-            logger.Info("Creating package.xml at " + windowsPackageXMLFileName);
-            PackageXMLWriter packageXMLWriter = new PackageXMLWriter(windowsPackageXMLFileName);
-            PackageXML packageXML = new PackageXML(PackageName);
-            packageXML.WriteElement(packageXMLWriter);
+                //Creating package.xml file
+                logger.Info("Creating package.xml at " + windowsPackageXMLFileName);
+                PackageXMLWriter packageXMLWriter = new PackageXMLWriter(windowsPackageXMLFileName);
+                PackageXML packageXML = new PackageXML(PackageName);
+                packageXML.WriteElement(packageXMLWriter);
 
-            //Creating RVIZ launch file
-            Rviz rviz = new Rviz(PackageName, URDFRobot.Name + ".urdf");
-            logger.Info("Creating RVIZ launch file in " + package.WindowsLaunchDirectory);
-            rviz.WriteFiles(package.WindowsLaunchDirectory);
+                //Creating RVIZ launch file
+                Rviz rviz = new Rviz(PackageName, robotURDF);
+                logger.Info("Creating RVIZ launch file in " + package.WindowsLaunchDirectory);
+                rviz.WriteFiles(package.WindowsLaunchDirectory);
 
-            //Creating Gazebo launch file
-            Gazebo gazebo = new Gazebo(URDFRobot.Name, PackageName, URDFRobot.Name + ".urdf");
-            logger.Info("Creating Gazebo launch file in " + package.WindowsLaunchDirectory);
+                //Creating Gazebo launch file
+                Gazebo gazebo = new Gazebo(URDFRobot.Name, PackageName, robotURDF);
+                logger.Info("Creating Gazebo launch file in " + package.WindowsLaunchDirectory);
 
-            gazebo.WriteFile(package.WindowsLaunchDirectory);
+                gazebo.WriteFile(package.WindowsLaunchDirectory);
+            }
 
             //Customizing STL preferences to how I want them
             logger.Info("Saving existing STL preferences");

--- a/SW2URDF/URDFExport/ExportHelper.cs
+++ b/SW2URDF/URDFExport/ExportHelper.cs
@@ -181,6 +181,19 @@ namespace SW2URDF.URDFExport
             iSwApp.GetUserProgressBar(out progressBar);
             progressBar.Start(0, progressBarBound, "Creating package directories");
 
+            // ROS 2 / colcon package names must be lowercase [a-z0-9_]; a default name like
+            // "3_DOF_ARM.SLDASM" would be rejected. Sanitize before the directory and files
+            // are created so the folder, package.xml <name> and CMake project all agree.
+            if (rosVersion == ROSVersion.ROS2)
+            {
+                string sanitized = ROS2Files.SanitizePackageName(PackageName);
+                if (sanitized != PackageName)
+                {
+                    logger.Info("Sanitized ROS 2 package name from '" + PackageName + "' to '" + sanitized + "'");
+                    PackageName = sanitized;
+                }
+            }
+
             //Creating package directories
             logger.Info("Creating package directories with name " + PackageName + " and save path " + SavePath);
             URDFPackage package = new URDFPackage(PackageName, SavePath);

--- a/SW2URDF/URDFExport/ExportHelper.cs
+++ b/SW2URDF/URDFExport/ExportHelper.cs
@@ -375,60 +375,9 @@ namespace SW2URDF.URDFExport
 
             logger.Info("Saving 3dxml to " + windowsMeshFilename);
 
-            // === 3dxml Localize Link === //
-
-            // Remove suffix from coordinate-system name.
-            // ex. "Joint Origin <Arm_link-1>" -> "Joint Origin"
-            // Suffix is included when coordinate is inside sub-assembly.
-            string linkModelName = names["component"];
-            string linkModelSuffix = " <" + linkModelName + ">";
-            if(coordsysName.Contains(linkModelSuffix))
-            {
-                coordsysName = coordsysName.Replace(linkModelSuffix, "");
-                logger.Info($"Suffix of {linkModelName} was removed from coordsysName : {coordsysName}");
-            }
-
-            // Get the model document of the link.
-            ModelDoc2 linkModel;
-            bool isBaseLink = linkModelName == "";
-            if (isBaseLink)
-            {
-                linkModel = ActiveDoc;
-            }
-            else
-            {
-                if (link.SWMainComponent != null)
-                {
-                    linkModel = link.SWMainComponent.GetModelDoc2();
-                }
-                else
-                {
-                    logger.Warn("Could not get linkModel because SWMainComponent was null");
-                    linkModel = null;
-                }
-            }
-
-            // Localize the link to the certain place.
-            if (linkModel != null)
-            {
-                MathTransform coordSysTransform =
-                    linkModel.Extension.GetCoordinateSystemTransformByName(coordsysName);
-                if (coordSysTransform != null)
-                {
-                    logger.Info("Localizing Link : " + coordsysName);
-                    Matrix<double> GlobalTransform = MathOps.GetTransformation(coordSysTransform);
-                    LocalizeLink(link, GlobalTransform);
-                }
-                else
-                {
-                    logger.Warn("coordSysTransform was null : " + coordsysName);
-                }
-            }
-            else
-            { 
-                logger.Warn("Link model was null.");
-            }
-            // === 3dxml Localize Link === //
+            // Align the link's visual/collision/inertial origins with its coordinate system
+            // so the exported mesh lines up with the URDF link frame.
+            LocalizeLinkToCoordinateSystem(link, coordsysName, names);
 
             ActiveDoc.Extension.SaveAs(windowsMeshFilename,
                 (int)swSaveAsVersion_e.swSaveAsCurrentVersion, saveOptions, null, ref errors, ref warnings);
@@ -461,6 +410,12 @@ namespace SW2URDF.URDFExport
                 (int)swSaveAsOptions_e.swSaveAsOptions_Copy;
             SetLinkSpecificSTLPreferences(names["geo"], link.STLQualityFine, ActiveDoc);
 
+            // Align the link's visual/collision/inertial origins with its coordinate system
+            // so the exported mesh lines up with the URDF link frame. Without this, STL meshes
+            // for links whose coordinate system is not at the assembly origin are misplaced
+            // (issues #87 / #116). Mirrors the 3dxml export path.
+            LocalizeLinkToCoordinateSystem(link, coordsysName, names);
+
             logger.Info("Saving STL to " + windowsMeshFilename);
             ActiveDoc.Extension.SaveAs(windowsMeshFilename,
                 (int)swSaveAsVersion_e.swSaveAsCurrentVersion, saveOptions, null, ref errors, ref warnings);
@@ -478,6 +433,66 @@ namespace SW2URDF.URDFExport
                     "may not be readable by CAD programs that aren't SolidWorks");
             }
             return success;
+        }
+
+        // Repositions the link's visual/collision/inertial origins into the link's own
+        // coordinate-system frame. The mesh itself is exported in the assembly's global
+        // frame, so this is what makes the mesh line up with the URDF link origin. Shared
+        // by the STL and 3dxml export paths.
+        private void LocalizeLinkToCoordinateSystem(Link link, string coordsysName,
+            Dictionary<string, string> names)
+        {
+            // Remove suffix from coordinate-system name.
+            // ex. "Joint Origin <Arm_link-1>" -> "Joint Origin"
+            // Suffix is included when coordinate is inside sub-assembly.
+            string linkModelName = names["component"];
+            string linkModelSuffix = " <" + linkModelName + ">";
+            if (coordsysName.Contains(linkModelSuffix))
+            {
+                coordsysName = coordsysName.Replace(linkModelSuffix, "");
+                logger.Info($"Suffix of {linkModelName} was removed from coordsysName : {coordsysName}");
+            }
+
+            // Get the model document of the link.
+            ModelDoc2 linkModel;
+            bool isBaseLink = linkModelName == "";
+            if (isBaseLink)
+            {
+                linkModel = ActiveSWModel;
+            }
+            else
+            {
+                if (link.SWMainComponent != null)
+                {
+                    linkModel = link.SWMainComponent.GetModelDoc2();
+                }
+                else
+                {
+                    logger.Warn("Could not get linkModel because SWMainComponent was null");
+                    linkModel = null;
+                }
+            }
+
+            // Localize the link to the certain place.
+            if (linkModel != null)
+            {
+                MathTransform coordSysTransform =
+                    linkModel.Extension.GetCoordinateSystemTransformByName(coordsysName);
+                if (coordSysTransform != null)
+                {
+                    logger.Info("Localizing Link : " + coordsysName);
+                    Matrix<double> GlobalTransform = MathOps.GetTransformation(coordSysTransform);
+                    LocalizeLink(link, GlobalTransform);
+                }
+                else
+                {
+                    logger.Warn("coordSysTransform was null : " + coordsysName);
+                }
+            }
+            else
+            {
+                logger.Warn("Link model was null.");
+            }
         }
 
         public void ExportLink(bool zIsUp)

--- a/SW2URDF/URDFExport/ExportHelper.cs
+++ b/SW2URDF/URDFExport/ExportHelper.cs
@@ -92,6 +92,15 @@ namespace SW2URDF.URDFExport
         private bool ComputeJointKinematics;
         private bool ComputeJointLimits;
 
+        // When true, reference coordinate systems and axes are searched at every component
+        // depth, not just the top level assembly and its immediate components. Default off.
+        private bool SearchNestedReferenceGeometry;
+
+        // Case-insensitive substring that an enumerated coordinate system / axis name must
+        // contain to appear in the dropdowns. Empty means no filtering. Useful to keep the
+        // lists manageable when SearchNestedReferenceGeometry is on.
+        private string ReferenceGeometryFilter;
+
         #endregion class variables
 
         // Constructor for SW2URDF Exporter class
@@ -102,6 +111,11 @@ namespace SW2URDF.URDFExport
 
             SavePath = System.Environment.ExpandEnvironmentVariables("%HOMEDRIVE%%HOMEPATH%");
             PackageName = ActiveSWModel.GetTitle();
+
+            // Defaults must be set before the initial enumeration below so that out-of-the-box
+            // behaviour (top level only, unfiltered) is unchanged.
+            SearchNestedReferenceGeometry = false;
+            ReferenceGeometryFilter = "";
 
             ReferenceCoordinateSystemNames = FindRefGeoNames("CoordSys");
             ReferenceAxesNames = FindRefGeoNames("RefAxis");
@@ -130,6 +144,22 @@ namespace SW2URDF.URDFExport
         public void SetComputeJointLimits(bool computeJointLimits)
         {
             ComputeJointLimits = computeJointLimits;
+        }
+
+        // Enable/disable searching for reference geometry in nested (deeper than top level)
+        // components, then refresh the coordinate system and axis lists.
+        public void SetSearchNestedReferenceGeometry(bool searchNested)
+        {
+            SearchNestedReferenceGeometry = searchNested;
+            UpdateReferenceGeometries();
+        }
+
+        // Set the case-insensitive name filter applied to enumerated reference geometry, then
+        // refresh the coordinate system and axis lists. Pass null or "" to disable filtering.
+        public void SetReferenceGeometryFilter(string filter)
+        {
+            ReferenceGeometryFilter = filter ?? "";
+            UpdateReferenceGeometries();
         }
 
         private void ConstructExporter(SldWorks iSldWorksApp)

--- a/SW2URDF/URDFExport/ExportHelper.cs
+++ b/SW2URDF/URDFExport/ExportHelper.cs
@@ -420,7 +420,7 @@ namespace SW2URDF.URDFExport
 
             // Align the link's visual/collision/inertial origins with its coordinate system
             // so the exported mesh lines up with the URDF link frame.
-            LocalizeLinkToCoordinateSystem(link, coordsysName, names);
+            LocalizeLinkToCoordinateSystem(link, coordsysName);
 
             ActiveDoc.Extension.SaveAs(windowsMeshFilename,
                 (int)swSaveAsVersion_e.swSaveAsCurrentVersion, saveOptions, null, ref errors, ref warnings);
@@ -457,7 +457,7 @@ namespace SW2URDF.URDFExport
             // so the exported mesh lines up with the URDF link frame. Without this, STL meshes
             // for links whose coordinate system is not at the assembly origin are misplaced
             // (issues #87 / #116). Mirrors the 3dxml export path.
-            LocalizeLinkToCoordinateSystem(link, coordsysName, names);
+            LocalizeLinkToCoordinateSystem(link, coordsysName);
 
             logger.Info("Saving STL to " + windowsMeshFilename);
             ActiveDoc.Extension.SaveAs(windowsMeshFilename,
@@ -478,63 +478,33 @@ namespace SW2URDF.URDFExport
             return success;
         }
 
-        // Repositions the link's visual/collision/inertial origins into the link's own
-        // coordinate-system frame. The mesh itself is exported in the assembly's global
-        // frame, so this is what makes the mesh line up with the URDF link origin. Shared
-        // by the STL and 3dxml export paths.
-        private void LocalizeLinkToCoordinateSystem(Link link, string coordsysName,
-            Dictionary<string, string> names)
+        // Repositions the link's visual/collision/inertial origins so the exported mesh lines
+        // up with the URDF link origin. The mesh is exported in the top-level assembly's global
+        // frame, and the joint that positions this link is also computed in that global frame
+        // (see GetCoordinateSystemTransform), so the mesh must be localized with the SAME global
+        // transform. GetCoordinateSystemTransform composes the owning component's Transform2,
+        // which SOLIDWORKS reports relative to the root assembly regardless of nesting depth
+        // (the per-level sub-assembly transforms must NOT be chained manually). That makes this
+        // depth-independent: it is correct for a coordinate system nested arbitrarily deep, not
+        // just at the top level or in an immediate component. Shared by the STL and 3dxml paths.
+        private void LocalizeLinkToCoordinateSystem(Link link, string coordsysName)
         {
-            // Remove suffix from coordinate-system name.
-            // ex. "Joint Origin <Arm_link-1>" -> "Joint Origin"
-            // Suffix is included when coordinate is inside sub-assembly.
-            string linkModelName = names["component"];
-            string linkModelSuffix = " <" + linkModelName + ">";
-            if (coordsysName.Contains(linkModelSuffix))
+            if (string.IsNullOrWhiteSpace(coordsysName))
             {
-                coordsysName = coordsysName.Replace(linkModelSuffix, "");
-                logger.Info($"Suffix of {linkModelName} was removed from coordsysName : {coordsysName}");
+                logger.Warn("No coordinate system for link " + link.Name + "; mesh origin not localized");
+                return;
             }
 
-            // Get the model document of the link.
-            ModelDoc2 linkModel;
-            bool isBaseLink = linkModelName == "";
-            if (isBaseLink)
+            MathTransform globalTransform = GetCoordinateSystemTransform(coordsysName);
+            if (globalTransform != null)
             {
-                linkModel = ActiveSWModel;
+                logger.Info("Localizing link " + link.Name + " mesh to global coordinate system " + coordsysName);
+                LocalizeLink(link, MathOps.GetTransformation(globalTransform));
             }
             else
             {
-                if (link.SWMainComponent != null)
-                {
-                    linkModel = link.SWMainComponent.GetModelDoc2();
-                }
-                else
-                {
-                    logger.Warn("Could not get linkModel because SWMainComponent was null");
-                    linkModel = null;
-                }
-            }
-
-            // Localize the link to the certain place.
-            if (linkModel != null)
-            {
-                MathTransform coordSysTransform =
-                    linkModel.Extension.GetCoordinateSystemTransformByName(coordsysName);
-                if (coordSysTransform != null)
-                {
-                    logger.Info("Localizing Link : " + coordsysName);
-                    Matrix<double> GlobalTransform = MathOps.GetTransformation(coordSysTransform);
-                    LocalizeLink(link, GlobalTransform);
-                }
-                else
-                {
-                    logger.Warn("coordSysTransform was null : " + coordsysName);
-                }
-            }
-            else
-            {
-                logger.Warn("Link model was null.");
+                logger.Warn("Could not resolve a global transform for coordinate system '" +
+                    coordsysName + "'; mesh origin not localized for link " + link.Name);
             }
         }
 

--- a/SW2URDF/URDFExport/ExportHelperExtension.cs
+++ b/SW2URDF/URDFExport/ExportHelperExtension.cs
@@ -1148,11 +1148,16 @@ namespace SW2URDF.URDFExport
                 logger.Info("Proceeding through assembly components");
                 AssemblyDoc assyDoc = (AssemblyDoc)modelDoc;
 
-                // Get top level components in an assembly. If the user wants to use a reference
-                // coordinate system or axis not located in the top level assembly, then it will
-                // need to be in a top level component. This will probably be ok because most
-                // users keep their reference geometry in the top level assembly as it is.
-                object[] components = assyDoc.GetComponents(true);
+                // By default we only look at the top level components in an assembly: reference
+                // geometry must then live in the top level assembly or a top level component,
+                // which is how most users organize their models.
+                //
+                // When SearchNestedReferenceGeometry is enabled we instead enumerate every
+                // component at every depth in a single flat pass (GetComponents(false)). Each
+                // Component2.Name2 returned this way is relative to the top level assembly, which
+                // is exactly what the transform resolution (GetCoordinateSystemTransform /
+                // GetRefAxis, also using GetComponents(false)) expects.
+                object[] components = assyDoc.GetComponents(!SearchNestedReferenceGeometry);
 
                 // If there are no components in an assembly, this object will be null.
                 if (components != null)
@@ -1163,9 +1168,15 @@ namespace SW2URDF.URDFExport
                         ModelDoc2 doc = comp.GetModelDoc2();
                         if (doc != null)
                         {
-                            //We already have all the components in an assembly, we don't want
-                            // to recur as we go through them. (topLevelOnly = true)
+                            //We already have all the components we need (flat in nested mode,
+                            // top level otherwise), so collect each component's own features
+                            // without recurring again. (topLevelOnly = true)
                             GetFeaturesOfType(doc, featureName, true, comp.Name2, features);
+                        }
+                        else
+                        {
+                            logger.Warn("Skipping reference geometry search in component with no " +
+                                "model document (lightweight or suppressed?): " + comp.Name2);
                         }
                     }
                 }
@@ -1204,6 +1215,14 @@ namespace SW2URDF.URDFExport
             {
                 foreach (Feature feat in features[key])
                 {
+                    // Skip names that don't match the (optional) name filter. Matching is on the
+                    // geometry's own name, not the "<component>" suffix.
+                    if (!string.IsNullOrEmpty(ReferenceGeometryFilter) &&
+                        feat.Name.IndexOf(ReferenceGeometryFilter, StringComparison.OrdinalIgnoreCase) < 0)
+                    {
+                        continue;
+                    }
+
                     if (String.IsNullOrWhiteSpace(key))
                     {
                         featureNames.Add(feat.Name);

--- a/SW2URDF/URDFExport/ExportPropertyManager.cs
+++ b/SW2URDF/URDFExport/ExportPropertyManager.cs
@@ -73,6 +73,8 @@ namespace SW2URDF.URDFExport
         private PropertyManagerPageCheckbox PMComputeVisualCollision;
         private PropertyManagerPageCheckbox PMComputeJointKinematics;
         private PropertyManagerPageCheckbox PMComputeJointLimits;
+        private PropertyManagerPageCheckbox PMSearchNestedGeometry;
+        private PropertyManagerPageTextbox PMReferenceGeometryFilter;
 
         private PropertyManagerPageLabel PMLabelJointName;
         private PropertyManagerPageLabel PMLabelParentLink;
@@ -110,6 +112,9 @@ namespace SW2URDF.URDFExport
         private const int ComputeJointKinematicsID = 29;
         private const int ComputeJointLimitsID = 30;
         private const int LoadedCSVFilenameID = 31;
+        private const int SearchNestedGeometryID = 32;
+        private const int ReferenceGeometryFilterID = 33;
+        private const int LabelReferenceGeometryFilterID = 34;
 
         #endregion class variables
 
@@ -489,6 +494,11 @@ namespace SW2URDF.URDFExport
                 LinkNode node = (LinkNode)Tree.SelectedNode;
                 node.Text = PMTextBoxLinkName.Text;
                 node.Name = PMTextBoxLinkName.Text;
+            }
+            else if (Id == ReferenceGeometryFilterID)
+            {
+                Exporter.SetReferenceGeometryFilter(Text);
+                RefreshReferenceGeometryControls();
             }
         }
 
@@ -945,6 +955,38 @@ namespace SW2URDF.URDFExport
                 ComputeJointLimitsID, (short)controlType, caption, (short)alignment, (int)options, tip);
             PMComputeJointLimits.Checked = true;
 
+            // Reference geometry search options. The checkbox enables searching for coordinate
+            // systems / axes in nested components; the textbox filters the listed names. Both
+            // re-enumerate and refresh the dropdowns immediately when changed.
+            controlType = (int)swPropertyManagerPageControlType_e.swControlType_Checkbox;
+            caption = "Search nested components";
+            alignment = (int)swPropertyManagerPageControlLeftAlign_e.swControlAlign_LeftEdge;
+            tip = "List coordinate systems and axes found inside sub-assemblies and parts, " +
+                "not just the top level assembly and its immediate components.";
+            options = (int)swAddControlOptions_e.swControlOptions_Visible +
+                (int)swAddControlOptions_e.swControlOptions_Enabled;
+            PMSearchNestedGeometry = PMGroup.AddControl2(
+                SearchNestedGeometryID, (short)controlType, caption, (short)alignment, (int)options, tip);
+            PMSearchNestedGeometry.Checked = false;
+
+            controlType = (int)swPropertyManagerPageControlType_e.swControlType_Label;
+            caption = "Filter reference geometry by name:";
+            alignment = (int)swPropertyManagerPageControlLeftAlign_e.swControlAlign_LeftEdge;
+            tip = "";
+            options = (int)swAddControlOptions_e.swControlOptions_Visible;
+            PMGroup.AddControl2(LabelReferenceGeometryFilterID, (short)controlType, caption,
+                (short)alignment, (int)options, tip);
+
+            controlType = (int)swPropertyManagerPageControlType_e.swControlType_Textbox;
+            caption = "";
+            alignment = (int)swPropertyManagerPageControlLeftAlign_e.swControlAlign_Indent;
+            tip = "Optional: only list coordinate systems / axes whose name contains this text " +
+                "(case-insensitive). Leave blank to list everything.";
+            options = (int)swAddControlOptions_e.swControlOptions_Visible +
+                (int)swAddControlOptions_e.swControlOptions_Enabled;
+            PMReferenceGeometryFilter = (PropertyManagerPageTextbox)PMGroup.AddControl2(
+                ReferenceGeometryFilterID, (short)controlType, caption, (short)alignment, (int)options, tip);
+
             options = (int)swAddControlOptions_e.swControlOptions_Visible +
                 (int)swAddControlOptions_e.swControlOptions_Enabled;
             PMButtonExport = PMGroup.AddControl2(ButtonExportID,
@@ -1003,8 +1045,29 @@ namespace SW2URDF.URDFExport
         // regularly called anyway
         void IPropertyManagerPage2Handler9.OnCheckboxCheck(int Id, bool Checked)
         {
-            logger.Info("OnCheckboxCheck called. This method no longer throws an Exception. " +
-                " It just silently does nothing. Ok, except for this logging message");
+            try
+            {
+                if (Id == SearchNestedGeometryID)
+                {
+                    Exporter.SetSearchNestedReferenceGeometry(Checked);
+                    RefreshReferenceGeometryControls();
+                }
+            }
+            catch (Exception e)
+            {
+                logger.Error("Exception caught handling checkbox " + Id, e);
+            }
+        }
+
+        // Re-fill the coordinate system / axis dropdowns for the currently selected node after
+        // the reference-geometry search options change.
+        private void RefreshReferenceGeometryControls()
+        {
+            LinkNode node = Tree?.SelectedNode as LinkNode;
+            if (node != null)
+            {
+                FillPropertyManager(node);
+            }
         }
 
         void IPropertyManagerPage2Handler9.OnComboboxEditChanged(int Id, string Text)

--- a/TESTING.md
+++ b/TESTING.md
@@ -1,0 +1,92 @@
+# Manual testing guide
+
+How to load this fork's add-in into SolidWorks and verify the changes on this
+branch. Everything here needs SolidWorks installed locally (it is a COM add-in).
+
+## 1. Build
+
+Open `SW2URDF.sln` in Visual Studio and build the **Debug** configuration, or
+from a shell:
+
+```powershell
+$msb = "C:\Program Files\Microsoft Visual Studio\18\Community\MSBuild\Current\Bin\MSBuild.exe"
+& $msb SW2URDF\SW2URDF.csproj /p:Configuration=Debug /p:SolutionDir="$PWD\"
+```
+
+Output: `SW2URDF\bin\Debug\SW2URDF.dll`.
+
+## 2. Register the add-in (needs administrator)
+
+SolidWorks loads the add-in from `HKEY_CLASSES_ROOT`, so registration needs
+admin rights. Two options:
+
+- **Visual Studio**: launch VS *as Administrator*, then build — the post-build
+  step runs RegAsm for you. To debug, set the SW2URDF project's
+  Debug > Start external program to
+  `C:\Program Files\SOLIDWORKS Corp\SOLIDWORKS\SLDWORKS.exe` and press F5.
+- **Script** (build normally, register once): from any shell run
+  ```powershell
+  pwsh -File scripts\register_addin.ps1
+  ```
+  It self-elevates. Use `-Unregister` to remove it, `-Configuration Release`
+  for a release build.
+
+Then start (or restart) SolidWorks — "SW2URDF Exporter" appears in the task pane.
+
+## 3. Test models
+
+Sample assemblies live under `examples/`:
+
+| Model | Notes |
+|-------|-------|
+| `3_DOF_ARM` | simple serial arm |
+| `4_WHEELER` | branched tree |
+| `ORIGINAL_3_DOF_ARM` | **has nested subassemblies** (`Arm_link.SLDASM`) — use for depth tests |
+| `TOY_BLOCK` | single part |
+
+## 4. What to verify per change
+
+### #1 — ROS 2 output (`feat(ros2)`)
+1. Open an example assembly, launch the exporter, build the tree, click
+   *Preview and Export*.
+2. In the export form, set **ROS Version = ROS 2**, finish the export.
+3. In the generated package, confirm:
+   - `package.xml` has `format="3"`, `<buildtool_depend>ament_cmake</buildtool_depend>`
+     and `<build_type>ament_cmake</build_type>`.
+   - `CMakeLists.txt` uses `find_package(ament_cmake REQUIRED)` + `ament_package()`.
+   - `launch/` contains `display.launch.py` and `gazebo.launch.py` (Python launch).
+4. Re-export with **ROS Version = ROS 1** and confirm the old catkin
+   `package.xml`/`CMakeLists.txt` + `display.launch`/`gazebo.launch` are unchanged.
+5. Optional end-to-end: `colcon build` the ROS 2 package, then
+   `ros2 launch <pkg> display.launch.py`.
+
+### #2 — STL coordinate fix (`fix(stl)`, issues #87 / #116)
+1. Use a model whose link coordinate system is **not** at the assembly origin
+   (offset/rotated). `ORIGINAL_3_DOF_ARM` is a good candidate.
+2. Export with **Mesh Format = STL**.
+3. Load the resulting URDF + meshes in RViz (or Isaac). The link meshes should
+   sit in the right place. Before the fix they were displaced.
+4. Sanity check: export the same model as **3dxml** and confirm the meshes line
+   up the same way (STL should now match 3dxml).
+
+### #3 / #4 — full-depth search + name filter (`feat(export)`)
+> Currently enabled programmatically via
+> `ExportHelper.SetSearchNestedReferenceGeometry(true)` /
+> `SetReferenceGeometryFilter("...")` (no UI toggle yet — that's a follow-up).
+1. With a model that has a coordinate system **inside a nested subassembly**
+   (depth ≥ 2), confirm that with the flag **off** it is *not* listed, and with
+   it **on** it *is* listed in the coordinate-system dropdown.
+2. With the filter set to a substring, confirm only matching names are listed.
+3. **Gate**: pick a depth-2 coordinate system, export, and confirm the link is
+   placed correctly. This validates that `Component2.Transform2` is
+   root-relative at depth ≥ 2 — the open question from the #0 analysis. If the
+   link is misplaced, depth resolution needs the parent-chain composition (a
+   larger change).
+
+## 5. Automated tests (optional)
+
+`TestRunner` runs the xunit integration tests (they launch SolidWorks and open
+the example models). It loads `SW2URDF\bin\x64\Debug\SW2URDF.dll`, so build the
+**x64 Debug** configuration first, then run `TestRunner.exe`
+(optionally `TestRunner.exe TestExportHelper` to filter by class). Note these
+tests only check structure/link counts, not mesh alignment.

--- a/TestRunner/TestRunner.csproj
+++ b/TestRunner/TestRunner.csproj
@@ -7,6 +7,9 @@
     <ApplicationIcon />
     <OutputType>Exe</OutputType>
     <StartupObject />
+    <!-- SolidWorks install dir, used to locate the interop assemblies. Override with
+         /p:SolidWorksDir=... or a SolidWorksDir env var if installed elsewhere. -->
+    <SolidWorksDir Condition=" '$(SolidWorksDir)' == '' ">C:\Program Files\SOLIDWORKS Corp\SOLIDWORKS\</SolidWorksDir>
   </PropertyGroup>
 
   <ItemGroup>
@@ -19,16 +22,16 @@
 
   <ItemGroup>
     <Reference Include="SolidWorks.Interop.sldworks">
-      <HintPath>..\..\..\..\..\Program Files\SOLIDWORKS Corp\SOLIDWORKS\SolidWorks.Interop.sldworks.dll</HintPath>
+      <HintPath>$(SolidWorksDir)SolidWorks.Interop.sldworks.dll</HintPath>
     </Reference>
     <Reference Include="SolidWorks.Interop.swconst">
-      <HintPath>..\..\..\..\..\Program Files\SOLIDWORKS Corp\SOLIDWORKS\SolidWorks.Interop.swconst.dll</HintPath>
+      <HintPath>$(SolidWorksDir)SolidWorks.Interop.swconst.dll</HintPath>
     </Reference>
     <Reference Include="SolidWorks.Interop.swpublished">
-      <HintPath>..\..\..\..\..\Program Files\SOLIDWORKS Corp\SOLIDWORKS\SolidWorks.Interop.swpublished.dll</HintPath>
+      <HintPath>$(SolidWorksDir)SolidWorks.Interop.swpublished.dll</HintPath>
     </Reference>
     <Reference Include="SolidWorksTools">
-      <HintPath>..\..\..\..\..\Program Files\SOLIDWORKS Corp\SOLIDWORKS\solidworkstools.dll</HintPath>
+      <HintPath>$(SolidWorksDir)solidworkstools.dll</HintPath>
     </Reference>
   </ItemGroup>
 

--- a/scripts/register_addin.ps1
+++ b/scripts/register_addin.ps1
@@ -1,0 +1,82 @@
+<#
+.SYNOPSIS
+    Register (or unregister) the built SW2URDF add-in with SolidWorks via RegAsm.
+
+.DESCRIPTION
+    SolidWorks loads SW2URDF as a COM add-in, which must be registered under
+    HKEY_CLASSES_ROOT - this needs administrator rights. Normally the project's
+    post-build step does this, but only when Visual Studio itself runs elevated.
+
+    This script lets you build normally (no elevation needed) and then register
+    the resulting DLL once. It self-elevates, so just run it from a normal shell:
+
+        pwsh -File scripts\register_addin.ps1
+        pwsh -File scripts\register_addin.ps1 -Unregister
+        pwsh -File scripts\register_addin.ps1 -Configuration Release
+
+    After registering, (re)start SolidWorks and the add-in appears in the task pane.
+
+.PARAMETER Configuration
+    Build configuration whose output to register. Default: Debug.
+
+.PARAMETER Platform
+    Output platform subfolder. "" for AnyCPU (bin\Debug), or "x64" (bin\x64\Debug).
+    Default: "" (AnyCPU).
+
+.PARAMETER Dll
+    Explicit path to SW2URDF.dll. Overrides Configuration/Platform if given.
+
+.PARAMETER Unregister
+    Unregister instead of register.
+#>
+[CmdletBinding()]
+param(
+    [string]$Configuration = "Debug",
+    [string]$Platform = "",
+    [string]$Dll = "",
+    [switch]$Unregister
+)
+
+$ErrorActionPreference = "Stop"
+
+# Resolve the DLL path (repo root is the parent of this script's folder).
+$repoRoot = Split-Path -Parent $PSScriptRoot
+if (-not $Dll) {
+    $platSub = if ($Platform) { "$Platform\" } else { "" }
+    $Dll = Join-Path $repoRoot "SW2URDF\bin\$platSub$Configuration\SW2URDF.dll"
+}
+if (-not (Test-Path $Dll)) {
+    Write-Error "SW2URDF.dll not found at: $Dll`nBuild the SW2URDF project first (Configuration=$Configuration, Platform='$Platform')."
+}
+$Dll = (Resolve-Path $Dll).Path
+
+# Re-launch elevated if we are not already administrator.
+$isAdmin = ([Security.Principal.WindowsPrincipal] `
+    [Security.Principal.WindowsIdentity]::GetCurrent()
+    ).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+if (-not $isAdmin) {
+    Write-Host "Elevating to administrator..."
+    $argList = @("-NoProfile", "-ExecutionPolicy", "Bypass", "-File", "`"$PSCommandPath`"",
+                 "-Dll", "`"$Dll`"")
+    if ($Unregister) { $argList += "-Unregister" }
+    Start-Process -FilePath (Get-Process -Id $PID).Path -Verb RunAs -ArgumentList $argList
+    return
+}
+
+$regasm = Join-Path $env:WINDIR "Microsoft.NET\Framework64\v4.0.30319\RegAsm.exe"
+if (-not (Test-Path $regasm)) {
+    Write-Error "RegAsm.exe (x64, v4.0.30319) not found at: $regasm"
+}
+
+if ($Unregister) {
+    Write-Host "Unregistering $Dll ..."
+    & $regasm /unregister $Dll
+} else {
+    Write-Host "Registering $Dll ..."
+    & $regasm /codebase $Dll
+}
+
+if ($LASTEXITCODE -ne 0) {
+    Write-Error "RegAsm failed with exit code $LASTEXITCODE."
+}
+Write-Host "Done. (Re)start SolidWorks to pick up the change." -ForegroundColor Green


### PR DESCRIPTION
## Summary
Fork improvements for a ROS 2 / Isaac Sim pipeline where reference geometry
lives inside parts (depth ≥ 1).

### Build
- chore(build): build on modern VS (.NET 4.8) and resolve SolidWorks interop
  via an overridable `$(SolidWorksDir)` instead of a fixed relative path.

### ROS 2 output  ✅ verified in SolidWorks
- feat(ros2): add a "ROS Version" selector; ROS 2 generates ament `package.xml`
  (format 3), an ament `CMakeLists.txt`, and Python launch files.
- feat(ros2): default the selector to ROS 2.
- fix(ros2): sanitize the package name so colcon accepts it
  (e.g. "3_DOF_ARM.SLDASM" -> "pkg_3_dof_arm").

### STL coordinate fix
- fix(stl): localize link origins on STL export (#87, #116), mirroring the
  existing 3dxml path. No-op when the coordinate system is at the origin.

### Full-depth reference geometry (opt-in)
- feat(export): optionally enumerate coordinate systems / axes in nested
  components, with a name filter; off by default.
- feat(export): expose both as toggles in the export PropertyManager.

### Docs
- docs(testing): manual test guide + self-elevating add-in registration script.

## Testing status
- ROS 2 package generation: verified end-to-end in SolidWorks.
- STL alignment (#87/#116): needs RViz/Isaac check on a model whose link
  coordinate system is offset from the assembly origin.
- Depth ≥ 2: needs confirmation that `Component2.Transform2` is root-relative at
  depth (mesh localization currently uses the component-local coordsys transform
  without composing the component's `Transform2`, unlike the joint-origin path —
  see review notes).