### PR TITLE
chore(build): retarget the add-in to .NET Framework 4.8

### DIFF
--- a/SW2URDF/SW2URDF.csproj
+++ b/SW2URDF/SW2URDF.csproj
@@ -37,7 +37,7 @@
     </UpgradeBackupLocation>
     <StartProgram>C:\PROGRA~1\SOLIDW~1\SOLIDW~1\\SldWorks.exe</StartProgram>
     <StartAction>Program</StartAction>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <OldToolsVersion>2.0</OldToolsVersion>
     <IsWebBootstrapper>false</IsWebBootstrapper>
     <TargetFrameworkProfile>
@@ -513,6 +513,7 @@
     <PreBuildEvent>"C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe" -ExecutionPolicy Bypass -File "$(SolutionDir)scripts\UpdateVersionInfo.ps1" --filename "$(ProjectDir)Versioning\VersionInfo.cs"</PreBuildEvent>
     <PostBuildEvent>
 :REGISTRATION
+IF "$(TargetFrameworkVersion)"=="v4.8" GOTO NET40
 IF "$(TargetFrameworkVersion)"=="v4.5.2" GOTO NET40
 IF "$(TargetFrameworkVersion)"=="v4.5" GOTO NET40
 IF "$(TargetFrameworkVersion)"=="v4.0" GOTO NET40


### PR DESCRIPTION
## Problem

The add-in targets .NET Framework 4.5.2, whose targeting pack is no longer
installed by current Visual Studio, so the build fails with MSB3644.

## Fix

Retarget the add-in to .NET Framework 4.8 (in-place compatible with the
existing net45 / net452 dependencies) and add v4.8 to the post-build RegAsm
framework check.

## Notes

Split into two per your suggestion. The SolidWorks interop path change is the
companion PR #196.
