### PR TITLE
fix(serialization): save the configuration as UTF-8 instead of ASCII

### DIFF
--- a/SW2URDF/URDFExport/ConfigurationSerialization.cs
+++ b/SW2URDF/URDFExport/ConfigurationSerialization.cs
@@ -165,7 +165,7 @@ namespace SW2URDF.URDFExport
                 {
                     ser.WriteObject(stream, link);
                     stream.Flush();
-                    data = Encoding.ASCII.GetString(stream.GetBuffer(), 0, (int)stream.Position);
+                    data = Encoding.UTF8.GetString(stream.GetBuffer(), 0, (int)stream.Position);
                 }
                 catch (SerializationException e)
                 {
@@ -185,7 +185,7 @@ namespace SW2URDF.URDFExport
             LinkNode baseNode = null;
             if (!string.IsNullOrWhiteSpace(data))
             {
-                using (MemoryStream stream = new MemoryStream(Encoding.ASCII.GetBytes(data)))
+                using (MemoryStream stream = new MemoryStream(Encoding.UTF8.GetBytes(data)))
                 {
                     DataContractSerializer ser =
                         new DataContractSerializer(typeof(Link));


### PR DESCRIPTION
## Problem
`ConfigurationSerialization` round-trips the DataContract XML through
`Encoding.ASCII`, which replaces every non-ASCII byte with `?`. Coordinate
system / axis / link names containing non-ASCII characters (e.g. Chinese) were
corrupted in the saved configuration, so on reload they no longer matched the
model and the selection was lost.

## Fix
Use UTF-8 (the encoding the XML is actually written in) for both directions.

## Compatibility
ASCII-only configurations are byte-identical, so existing saved configurations
are unaffected.

## Testing
Verified: coordinate system names containing non-ASCII (Chinese) characters now
persist across save / reload.
