### PR TITLE
fix(ros1): drop the unused model arg from the generated display.launch

### DIFF
--- a/SW2URDF/ROS/ROSFiles.cs
+++ b/SW2URDF/ROS/ROSFiles.cs
@@ -229,7 +229,6 @@ namespace SW2URDF.ROS
 
             elements = new List<LaunchElement>
             {
-                new LaunchArg("model"),
                 new LaunchParam("robot_description", "", "$(find " + package + ")/urdf/" + robotURDF),
                 new LaunchNode("joint_state_publisher_gui", "joint_state_publisher_gui", "joint_state_publisher_gui"),
                 new LaunchNode("robot_state_publisher", "robot_state_publisher", "robot_state_publisher"),


### PR DESCRIPTION
## Problem

The generated `display.launch` declares `<arg name="model" />` with no
default and no `$(arg model)` reference anywhere in the file —
`robot_description` is loaded directly from `$(find pkg)/urdf/...`. The
orphan arg makes `roslaunch-check` report `No value for arg [model]`.
Runtime `roslaunch` is unaffected.

## Fix

Remove the unused declaration so the launch file lints cleanly. No other
output changes; the `LaunchArg` building block is kept for use by other
launch elements.

## Testing

Builds clean. Generated `display.launch` no longer contains the `model`
arg; `robot_description`, the state publishers, and the RViz node are
unchanged.