### PR TITLE
fix(export): bake STL meshes for coordinate systems nested in sub-assemblies

### DIFF
--- a/SW2URDF/URDFExport/ExportHelper.cs
+++ b/SW2URDF/URDFExport/ExportHelper.cs
@@ -439,11 +439,28 @@ namespace SW2URDF.URDFExport
 
             logger.Info(link.Name + ": Reference geometry name " + names["component"]);
 
+            // Choose the coordinate system SOLIDWORKS exports the STL relative to. The export
+            // preference only resolves names that exist at the top level of the assembly, so a
+            // coordinate system defined inside a sub-assembly cannot be used directly and the
+            // mesh falls back to the global frame (issues #87 / #116). When the selection is
+            // nested, materialize a top-level reference coordinate system at the same global
+            // pose -- the transform the joint origin already uses, which is depth-independent --
+            // and export relative to that, so the mesh stays baked at the link origin.
+            string exportCoordsysName = names["geo"];
+            if (!string.IsNullOrEmpty(names["component"]))
+            {
+                string nestedExportCoordsys = CreateGlobalMeshCoordinateSystem(link, coordsysName);
+                if (!string.IsNullOrEmpty(nestedExportCoordsys))
+                {
+                    exportCoordsysName = nestedExportCoordsys;
+                }
+            }
+
             CommonSwOperations.ShowComponents(ActiveSWModel, link.SWComponents);
 
             int saveOptions = (int)swSaveAsOptions_e.swSaveAsOptions_Silent |
                 (int)swSaveAsOptions_e.swSaveAsOptions_Copy;
-            SetLinkSpecificSTLPreferences(names["geo"], link.STLQualityFine, ActiveDoc);
+            SetLinkSpecificSTLPreferences(exportCoordsysName, link.STLQualityFine, ActiveDoc);
 
             logger.Info("Saving STL to " + windowsMeshFilename);
             ActiveDoc.Extension.SaveAs(windowsMeshFilename,

--- a/SW2URDF/URDFExport/ExportHelperExtension.cs
+++ b/SW2URDF/URDFExport/ExportHelperExtension.cs
@@ -586,6 +586,53 @@ namespace SW2URDF.URDFExport
             }
         }
 
+        // Materializes a top-level reference coordinate system at the global pose of a
+        // (possibly nested) coordinate system, and returns its name. The STL export
+        // coordinate-system preference only resolves coordinate systems at the top level of the
+        // document being saved, so a system defined inside a sub-assembly cannot be used to
+        // localize the mesh and SOLIDWORKS falls back to the global frame.
+        // The global transform is taken from GetCoordinateSystemTransform -- the same one the
+        // joint origin uses, which composes the owning component's Transform2 and is therefore
+        // correct at any nesting depth -- so the generated top-level system coincides with the
+        // selected one and the mesh is baked at the link origin, exactly as the auto-generated
+        // Origin_<joint> systems already are. Returns null if the transform cannot be resolved.
+        private string CreateGlobalMeshCoordinateSystem(Link link, string coordsysName)
+        {
+            MathTransform globalTransform = GetCoordinateSystemTransform(coordsysName);
+            if (globalTransform == null)
+            {
+                logger.Warn("Could not resolve a global transform for '" + coordsysName +
+                    "'; mesh for link " + link.Name + " will be exported in the global frame");
+                return null;
+            }
+
+            if (referenceSketchName == null)
+            {
+                referenceSketchName = Setup3DSketch();
+            }
+
+            Joint meshFrame = new Joint();
+            meshFrame.Origin.SetXYZ(MathOps.GetXYZ(globalTransform));
+            meshFrame.Origin.SetRPY(MathOps.GetRPY(globalTransform));
+
+            // Pick a unique top-level name (the model may already hold one from a prior export,
+            // mirroring how auto-generated Origin_<joint> names are de-duplicated).
+            string baseName = "Mesh_origin_" + link.Name.Replace('/', '_');
+            string name = baseName;
+            int i = 2;
+            ActiveSWModel.ClearSelection2(true);
+            while (ActiveSWModel.Extension.SelectByID2(name, "COORDSYS", 0, 0, 0, false, 0, null, 0))
+            {
+                ActiveSWModel.ClearSelection2(true);
+                name = baseName + i.ToString();
+                i++;
+            }
+
+            meshFrame.CoordinateSystemName = name;
+            CreateRefOrigin(meshFrame);
+            return name;
+        }
+
         // Creates a Reference Axis to be used to calculate the joint axis
         private void CreateRefAxis(Joint Joint)
         {


### PR DESCRIPTION
## Problem

When a link's reference coordinate system is defined inside a sub-assembly,
`SaveSTL` passed its bare name to the SOLIDWORKS save-as-coordinate-system
preference. That preference only resolves names at the top level of the
document being saved, so the nested name is not found and the mesh is exported
in the global frame. The joint origin, by contrast, is computed from the nested
frame via `GetCoordinateSystemTransform` (which composes the owning component's
`Transform2`), so the mesh and the joint disagree and the link is rendered
double-transformed. This is the long-standing behaviour in #116 and the closed
#87; the "Automatically Generate" path avoids it only because it always creates
a top-level `Origin_<joint>` coordinate system the preference can resolve.

## Fix

When the selected coordinate system is nested (its `<component>` suffix is
present), materialize a top-level reference coordinate system at the same global
pose -- the transform `GetCoordinateSystemTransform` already returns, which is
depth-independent -- and export the STL relative to it. The mesh is then baked
at the link origin (visual origin stays zero, the joint carries the placement),
consistent with the top-level and auto-generate cases, and the same part
exported in two places yields the same reusable mesh.

Top-level and auto-generate selections are unchanged: their component suffix is
empty, so the existing path is taken and the `SetLinkSpecificSTLPreferences`
call is identical. Scope is the STL export; the 3dxml path keeps its own
localization.

## Relationship to #182

#182 modernizes the obsolete preference enum and fixes the top-level (depth-0)
case. This is the nested-coordinate-system extension I described at
https://github.com/ros/solidworks_urdf_exporter/pull/182#issuecomment-4601085813
-- the two compose. The existing enum is kept here so the change builds and runs
on SW 2022 (the `swExportOutputCoordinateSystem` constant is not present in that
interop); happy to rebase onto #182 once it lands.

## Testing

Depth-3 mecanum chassis on SW 2022 (reference coordinate systems two levels
deep: chassis / drive / wheel):

- Before: wheel meshes exported in the global frame; wheels rendered away from
  their axles.
- After: each wheel STL is centered on its own origin (the four wheels are
  byte-identical, reusable meshes) and they render at the correct positions in
  RViz.
- A 3-DOF arm (top-level coordinate systems) re-exports unchanged.

Requires #193 for the nested meshes to contain geometry in the first place.
Relates to #87 / #116 / #168.
