### PR TITLE
fix(ui): correct the moment-of-inertia unit label (kg*m^2, not kg*m^-2)

### DIFF
--- a/SW2URDF/UI/AssemblyExportForm.Designer.cs
+++ b/SW2URDF/UI/AssemblyExportForm.Designer.cs
@@ -462,7 +462,7 @@
             this.label44.Name = "label44";
             this.label44.Size = new System.Drawing.Size(144, 13);
             this.label44.TabIndex = 23;
-            this.label44.Text = "Moment of Inertia (Kg * m^-2)";
+            this.label44.Text = "Moment of Inertia (Kg * m^2)";
             // 
             // label45
             // 

--- a/SW2URDF/UI/PartExportForm.Designer.cs
+++ b/SW2URDF/UI/PartExportForm.Designer.cs
@@ -288,7 +288,7 @@
             this.label12.Name = "label12";
             this.label12.Size = new System.Drawing.Size(144, 13);
             this.label12.TabIndex = 23;
-            this.label12.Text = "Moment of Inertia (Kg * m^-2)";
+            this.label12.Text = "Moment of Inertia (Kg * m^2)";
             // 
             // label13
             // 


### PR DESCRIPTION
The Preview/Export form labelled the moment of inertia `Kg * m^-2`, which is `kg/m^2` — wrong for an inertia. Moment of inertia is `kg·m^2`. The exported values are unaffected (`IMassProperty` returns system/SI units); this is just the label. Reported in #198.
